### PR TITLE
Add dynamic metric fetching, responsive sizing and settings modal to StockChartCard

### DIFF
--- a/client/components/fetchMetrics.tsx
+++ b/client/components/fetchMetrics.tsx
@@ -1,0 +1,44 @@
+import { MetricType, GraphSettings } from './graphSettingsModal';
+import { stockDataMap } from './StockCardComponent';
+
+export interface TimeSeriesPoint {
+  date: string;   
+  value: number;
+}
+
+export interface MetricsResponse {
+  metricType: MetricType | 'OHLC';
+  series:
+    | { ohlc: typeof stockDataMap[string] }     
+    | { points: TimeSeriesPoint[] };    
+}
+
+interface FetchMetricsRequest {
+  ticker: string;
+  settings: GraphSettings | null;
+}
+
+export async function fetchMetrics(
+  req: FetchMetricsRequest
+): Promise<MetricsResponse> {
+  await new Promise((r) => setTimeout(r, 250));
+
+  if (!req.settings) {
+    const all = stockDataMap[req.ticker] ?? [];
+    return { metricType: 'OHLC', series: { ohlc: all } };
+  }
+
+  const { startDate, endDate } = req.settings.metricParams;
+  const start = new Date(startDate);
+  const end   = new Date(endDate);
+  const msDay = 86_400_000;
+
+  const points: TimeSeriesPoint[] = [];
+  for (let t = start.getTime(), i = 0; t <= end.getTime(); t += msDay, ++i) {
+    const date  = new Date(t).toISOString().slice(0, 10);
+    const value = 1 + Math.sin(i / 3) + Math.random() * 0.25;
+    points.push({ date, value: +value.toFixed(3) });
+  }
+
+  return { metricType: req.settings.metricType, series: { points } };
+}


### PR DESCRIPTION
This PR transforms the StockChartCard from a static OHLC display into a configurable, dynamic charting component.  A new fetchMetrics API stub is introduced to return either the full OHLC series or a time series based on user selected settings. The card now opens a GraphSettingsModal, and when the user applies new start and end dates, metric type or colour, StockChartCard calls fetchMetrics and updates its internal chartData and barColor state.

The component is now fully responsive now a ResizeObserver on containerRef tracks the card’s width and height and passes those dimensions into the chosen chart component.  A fullscreen toggle button lets users expand the chart to cover the entire screen.