### PR TITLE
fix bug of graph sync

### DIFF
--- a/client/components/GraphSettingsContext.tsx
+++ b/client/components/GraphSettingsContext.tsx
@@ -1,0 +1,42 @@
+import { createContext, useState, ReactNode } from 'react';
+
+// Defined global graph setting
+export interface GraphSettings {
+  selectedStocks: (string | null)[];
+  globalStart: string;
+  globalEnd: string;
+}
+
+interface GraphSettingsContextValue {
+  settings: GraphSettings;
+  setSettings: React.Dispatch<React.SetStateAction<GraphSettings>>;
+}
+
+// Create context, and setting defalt data
+export const GraphSettingsContext = createContext<GraphSettingsContextValue>({
+  settings: {
+    selectedStocks: [null, null, null, null, null, null],
+    globalStart: '',
+    globalEnd: ''
+  },
+  setSettings: () => {}
+});
+
+// Create provider
+export const GraphSettingsProvider = ({ children }: { children: ReactNode }) => {
+  const nowISO = new Date(Date.now() - new Date().getTimezoneOffset() * 60000)
+    .toISOString()
+    .slice(0,16);
+
+  const [settings, setSettings] = useState<GraphSettings>({
+    selectedStocks: [null, null, null, null, null, null],
+    globalStart: nowISO,
+    globalEnd: nowISO
+  });
+
+  return (
+    <GraphSettingsContext.Provider value={{ settings, setSettings }}>
+      {children}
+    </GraphSettingsContext.Provider>
+  );
+};

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -4,11 +4,15 @@ import DashboardView from "@/pages/dashboardView";
 import React from "react";
 import Index from "@/pages/index";
 import { AuthProvider } from "@/components/authContext";
+import { GraphSettingsProvider } from '@/components/GraphSettingsContext';
+
 
 export default function App({ Component, pageProps }: AppProps) {
     return (
     <AuthProvider>
-        <Component {...pageProps} />
+        <GraphSettingsProvider>
+            <Component {...pageProps} />
+        </GraphSettingsProvider>
     </AuthProvider>
   )
 }


### PR DESCRIPTION
# Sync graph settings between Dashboard and Index pages

**Related issues:**
- Closes #62  
- Part of Design graph process #37

## Overview

This PR centralizes our “Portfolio / StockChart” settings—selected tickers and date range—into a React Context (`GraphSettingsContext`) so that:

1. Changing settings on **DashboardView** immediately propagates to **Index** without a full reload.
2. The Index page now mirrors Dashboard’s responsive grid:
   - A large primary chart (sm=8)  
   - Two stacked secondary charts (sm=4)  
   - Three tertiary charts in a bottom row  

## What’s changed

1. **`context/GraphSettingsContext.tsx`**  
   - Defines `GraphSettings` interface and `GraphSettingsProvider`.  
   - Wraps `<App />` so both pages share the same `settings` + `setSettings`.

2. **`pages/_app.tsx`**  
   - Import and wrap with `<GraphSettingsProvider>`.

3. **`pages/dashboardView.tsx`**  
   - Replace local `useState` for `selectedStocks`, `globalStart`, `globalEnd` with `useContext(GraphSettingsContext)`.  
   - Handlers (`onSelectStock`, `onClear`, `onSwap`, `onApplySettings`) now call `setSettings(...)`.  
   - Layout unchanged.

4. **`pages/index.tsx`**  
   - Import `GraphSettingsContext` and read `settings`.  
   - Use the same `<StockChartCard>` grid structure as DashboardView.  