### PR TITLE
Set and Update the Help and Giude page

### DIFF
--- a/client/pages/Guide.tsx
+++ b/client/pages/Guide.tsx
@@ -7,8 +7,8 @@ function Guide() {
       <Sidebar />
       <div style={{ flex: 1, paddingLeft: "50px" }}>
         {/* Your portfolio page content will go here */}
-        <h1>Market News</h1>
-        <p>This is where you can add your market news content.</p>
+        <h1>Guide</h1>
+        <p>This is where you can add your guide content.</p>
       </div>
     </div>
   );

--- a/client/pages/Guide.tsx
+++ b/client/pages/Guide.tsx
@@ -1,17 +1,159 @@
-import React from "react";
-import Sidebar from "@/components/sidebar"; // Adjust the path to match where Sidebar is located in your project
+import React from 'react';
+import Sidebar from '@/components/sidebar';
 
-function Guide() {
+interface TOCItem { id: string; label: string; }
+interface TableOfContentsProps { items: TOCItem[]; }
+
+const TableOfContents: React.FC<TableOfContentsProps> = ({ items }) => (
+  <nav style={{
+    marginBottom: '1.5rem',
+    padding: '1rem',
+    backgroundColor: '#f9fafb',
+    borderLeft: '4px solid #0070f3', 
+    borderRadius: '4px',
+    boxShadow: '0 2px 4px rgba(0,0,0,0.05)',
+    position: 'sticky',              
+    top: '1rem',
+  }}>
+    <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+      {items.map(item => (
+        <li key={item.id} style={{ margin: '0.5rem 0' }}>
+          <a
+            href={`#${item.id}`}
+            style={{
+              color: '#0070f3',
+              textDecoration: 'none',
+              fontSize: '1rem',
+              fontWeight: 500,
+            }}
+          >
+            {item.label}
+          </a>
+        </li>
+      ))}
+    </ul>
+  </nav>
+);
+
+const Guide: React.FC = () => {
+  const tocItems: TOCItem[] = [
+    { id: 'login-signup', label: 'Login and SignUp' },
+    { id: 'portfolio',    label: 'Portfolio' },
+    { id: 'top-picks',    label: 'Top Picks' },
+    { id: 'market-news',  label: 'Market News' },
+    { id: 'watchlist',    label: 'Watchlist' },
+    { id: 'community',    label: 'Community' },
+    { id: 'profile',      label: 'Profile' },
+  ];
+
   return (
-    <div style={{ display: "flex" }}>
+    <div style={{ display: 'flex', height: '100vh' }}>
       <Sidebar />
-      <div style={{ flex: 1, paddingLeft: "50px" }}>
-        {/* Your portfolio page content will go here */}
-        <h1>Guide</h1>
-        <p>This is where you can add your guide content.</p>
+      <div style={{ flex: 1, paddingLeft: '50px' }}>
+        <main style={{
+          flex: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          padding: '2rem',
+          overflowY: 'auto',
+        }}>
+          <h1 style={{ fontSize: '2rem', fontWeight: 'bold', marginBottom: '1.5rem' }}>
+            Guide
+          </h1>
+
+          <TableOfContents items={tocItems} />
+
+          {/* main content */}
+          <section id="login-signup" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Login and SignUp
+            </h2>
+            {/* TODO*/}
+            <p style={{ marginBottom: '1rem' }}>
+                A unified form layout lets users either register or authenticate, with field sets and button labels changing based on mode.
+            </p>
+
+            <h3 style={{ fontSize: '1.25rem', fontWeight: '500', marginBottom: '0.5rem' }}>Sign Up</h3>
+            <ul style={{ marginBottom: '1rem', paddingLeft: '1.25rem' }}>
+                <li><strong>Fields:</strong> First name, last name, email, password</li>
+                <li><strong>Primary Button:</strong> “Sign up” (creates account + confirmation email)</li>
+                <li><strong>OAuth Option:</strong> “Sign up with Google” (one-click registration)</li>
+            </ul>
+
+            <h3 style={{ fontSize: '1.25rem', fontWeight: '500', marginBottom: '0.5rem' }}>Log In</h3>
+            <ul style={{ marginBottom: '1rem', paddingLeft: '1.25rem' }}>
+                <li><strong>Fields:</strong> Email, password</li>
+                <li><strong>Primary Button:</strong> “Log in” (standard email/password auth)</li>
+                <li><strong>OAuth Option:</strong> “Log in with Google” (Google OAuth)</li>
+            </ul>
+
+            <h3 style={{ fontSize: '1.25rem', fontWeight: '500', marginBottom: '0.5rem' }}>Key Functional Points</h3>
+            <ul style={{ paddingLeft: '1.25rem' }}>
+                <li>Inline validation for field errors (e.g. invalid email, weak password)</li>
+                <li>Sticky labels and clear focus states for accessibility</li>
+                <li>Responsive: two-column inputs collapse to single column on narrow screens</li>
+            </ul>
+          </section>
+
+          <section id="portfolio" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Portfolio
+            </h2>
+                <p style={{ marginBottom: '1rem' }}>
+                Users can search and select a stock via the top search bar. 
+                </p>
+                <p style={{ marginBottom: '1rem' }}>
+                the main chart pane then displays the chosen ticker's data.
+                </p>
+
+                <ul style={{ marginBottom: '1rem', paddingLeft: '1.25rem' }}>
+                <li><strong>Main block:</strong> Renders the selected stock's interactive chart.</li>
+                <li><strong>Mini blocks (x5):</strong> Swap any chart into the main pane using the ↔ button.</li>
+                <li><strong>Settings (⚙️):</strong> Adjust metric type, start/end dates, series color, and other metric‑specific parameters per pane.</li>
+                <li><strong>Sync:</strong> User-defined chart configurations automatically sync to the dashboard for consistent display.</li>
+                </ul>
+          </section>
+
+          <section id="top-picks" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Top Picks
+            </h2>
+            {/* TODO*/}
+          </section>
+
+          <section id="market-news" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Market News
+            </h2>
+            {/* TODO*/}
+          </section>
+
+          <section id="watchlist" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Watchlist
+            </h2>
+            {/* TODO*/}
+          </section>
+
+          <section id="community" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Community
+            </h2>
+            {/* TODO*/}
+          </section>
+
+          <section id="profile" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Profile
+            </h2>
+            {/* TODO*/}
+          </section>
+
+          
+        </main>
       </div>
     </div>
   );
-}
+};
 
 export default Guide;

--- a/client/pages/Guide.tsx
+++ b/client/pages/Guide.tsx
@@ -98,7 +98,6 @@ const Guide: React.FC = () => {
           <section id="portfolio" style={{ marginBottom: '2rem' }}>
             <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
                 Portfolio
-                {/* test */}
             </h2>
                 <p style={{ marginBottom: '1rem' }}>
                 Users can search and select a stock via the top search bar. 

--- a/client/pages/Guide.tsx
+++ b/client/pages/Guide.tsx
@@ -1,17 +1,255 @@
-import React from "react";
-import Sidebar from "@/components/sidebar"; // Adjust the path to match where Sidebar is located in your project
+import React from 'react';
+import Sidebar from '@/components/sidebar';
 
-function Guide() {
+interface TOCItem { id: string; label: string; }
+interface TableOfContentsProps { items: TOCItem[]; }
+
+const TableOfContents: React.FC<TableOfContentsProps> = ({ items }) => (
+  <nav style={{
+    marginBottom: '1.5rem',
+    padding: '1rem',
+    backgroundColor: '#f9fafb',
+    borderLeft: '4px solid #0070f3', 
+    borderRadius: '4px',
+    boxShadow: '0 2px 4px rgba(0,0,0,0.05)',
+    position: 'sticky',              
+    top: '1rem',
+  }}>
+    <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+      {items.map(item => (
+        <li key={item.id} style={{ margin: '0.5rem 0' }}>
+          <a
+            href={`#${item.id}`}
+            style={{
+              color: '#0070f3',
+              textDecoration: 'none',
+              fontSize: '1rem',
+              fontWeight: 500,
+            }}
+          >
+            {item.label}
+          </a>
+        </li>
+      ))}
+    </ul>
+  </nav>
+);
+
+const Guide: React.FC = () => {
+  const tocItems: TOCItem[] = [
+    { id: 'General', label: 'Guide' },
+    { id: 'BetaAnalysis', label: 'Beta Analysis' },
+    { id: 'AlphaComparison',    label: 'Alpha Comparison' },
+    { id: 'MaxDrawdownAnalysis',    label: 'Max Drawdown' },
+    { id: 'CumulativeReturnComparison',  label: 'Cumulative Return' },
+    { id: 'SortinoRatioVisualization',    label: 'Sortino Ratio' },
+    { id: 'MarketCorrelationAnalysis',    label: 'Market Correlation' },
+    { id: 'SharpeRatioMatrix',      label: 'Sharpe Ratio' },
+    { id: 'ValueAtRiskAnalysis',      label: 'Value at Risk' },
+    { id: 'EfficientFrontierVisualization',      label: 'Efficient Frontier' }
+  ];
+
   return (
-    <div style={{ display: "flex" }}>
+    <div style={{ display: 'flex', height: '100vh' }}>
       <Sidebar />
-      <div style={{ flex: 1, paddingLeft: "50px" }}>
-        {/* Your portfolio page content will go here */}
-        <h1>Guide</h1>
-        <p>This is where you can add your guide content.</p>
+
+      {/* Wrapper ensures content and TOC shift right to avoid sidebar overlap */}
+      <div style={{ flex: 1, paddingLeft: '70px', display: 'flex' }}>
+        {/* Sticky Table of Contents */}
+        <aside
+          style={{
+            width: '250px',
+            marginRight: '2rem',
+            position: 'sticky',
+            top: '2rem',
+            alignSelf: 'flex-start',
+            height: 'fit-content',
+          }}
+        >
+          <TableOfContents items={tocItems} />
+        </aside>
+
+        {/* Scrollable main content */}
+        <div
+          style={{
+            flex: 1,
+            overflowY: 'auto',
+            padding: '2rem',
+            boxSizing: 'border-box',
+          }}
+        >
+        <section id="General" style={{ marginBottom: '2rem' }}>
+          <h1 style={{ fontSize: '2rem', fontWeight: 'bold', marginBottom: '1.5rem' }}>
+            Guide
+          </h1>
+
+            <p style={{ marginBottom: '1rem' }}>
+              In this Guide you will learn how to explore and customize all of our built-in financial metrics.
+            </p>
+
+            <ul style={{ marginBottom: '1rem', paddingLeft: '1.25rem' }}>
+                <li><strong>Step1:</strong> Click the Settings button above any chart to open the metrics modal.</li>
+                <li><strong>Step2:</strong> In the modal, choose your Metric Type, set a Start Date and End Date, pick a Series Color, and fill in any extra fields that appear (like benchmark ticker, risk-free rate, or confidence level).</li>
+                <li><strong>Step3:</strong> Hit Apply to generate or update your chart.</li>
+            </ul>
+
+            <p style={{ marginBottom: '1rem' }}>
+                Use the table of contents on the left to jump to detailed instructions for each metric.
+            </p>
+            
+          </section>
+
+          <section id="BetaAnalysis" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Beta Analysis
+            </h2>
+            <p style={{ marginBottom: '1rem' }}>
+                Beta measures how sensitive your portfolio (or individual stock) is to overall market movements.
+            </p>
+
+            <ul style={{ marginBottom: '1rem', paddingLeft: '1.25rem' }}>
+                <li><strong>Metric Type:</strong> Select “Beta Analysis”.</li>
+                <li><strong>Market Ticker:</strong> Enter the symbol of the benchmark index (e.g. S&P 500 or “AMZN” for Amazon).</li>
+                <li><strong>Date Range:</strong> Choose the period over which you want to calculate beta.
+                Once applied, you will see a time series of rolling beta values. 
+                A beta greater than 1 indicates higher volatility than the market; 
+                a beta below 1 indicates lower volatility.</li>
+            </ul>
+            
+          </section>
+
+          <section id="AlphaComparison" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Alpha Comparison
+            </h2>
+            <p style={{ marginBottom: '1rem' }}>
+                Alpha represents the excess return of your portfolio relative to a risk-free investment.
+            </p>
+
+            <ul style={{ marginBottom: '1rem', paddingLeft: '1.25rem' }}>
+                <li><strong>Metric Type:</strong> Choose “Alpha Comparison”.</li>
+                <li><strong>Risk-Free Rate:</strong> Enter the annual risk-free rate (e.g. 0.02 for 2%). </li>
+                <li><strong>Date Range:</strong> Define the timeframe for analysis.
+                The resulting chart shows cumulative excess returns above the risk-free rate, 
+                helping you see how much additional value you captured.</li>
+            </ul>
+          </section>
+
+          <section id="MaxDrawdownAnalysis" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Max Drawdown
+            </h2>
+            <p style={{ marginBottom: '1rem' }}>
+                Max Drawdown shows the largest peak-to-trough loss your portfolio experienced during the selected period.
+            </p>
+
+            <ul style={{ marginBottom: '1rem', paddingLeft: '1.25rem' }}>
+                <li><strong>Metric Type:</strong> Select “Max Drawdown”.</li>
+                <li><strong>Date Range:</strong> Pick the window you want to examine.
+                You will get a chart highlighting each drawdown cycle, 
+                with the maximum decline prominently marked—ideal for understanding worst-case risk.</li>
+            </ul>
+          </section>
+
+          <section id="CumulativeReturnComparison" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Cumulative Return
+            </h2>
+            <p style={{ marginBottom: '1rem' }}>
+                Cumulative Return tracks how an initial investment grows (or shrinks) over time.
+            </p>
+
+            <ul style={{ marginBottom: '1rem', paddingLeft: '1.25rem' }}>
+                <li><strong>Metric Type:</strong> Pick “Cumulative Return”.</li>
+                <li><strong>Date Range:</strong> Choose your start and end dates.
+                The chart displays the compounded return curve—great for visualizing 
+                long-term performance without worrying about volatility measures.</li>
+            </ul>
+          </section>
+
+          <section id="SortinoRatioVisualization" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Sortino Ratio
+            </h2>
+            <p style={{ marginBottom: '1rem' }}>
+                Sortino Ratio is a risk-adjusted performance metric that penalizes only downside volatility.
+            </p>
+
+            <ul style={{ marginBottom: '1rem', paddingLeft: '1.25rem' }}>
+                <li><strong>Metric Type:</strong> Select “Sortino Ratio”.</li>
+                <li><strong>Risk-Free Rate:</strong> Provide the annual risk-free rate. </li>
+                <li><strong>Date Range:</strong> Set the analysis period.
+                You'll see a time series of Sortino values—higher values indicate better downside risk-adjusted performance.</li>
+            </ul>
+          </section>
+
+          <section id="MarketCorrelationAnalysis" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Market Correlation
+            </h2>
+            <p style={{ marginBottom: '1rem' }}>
+                Correlation measures how closely your portfolio moves in sync with a benchmark.
+            </p>
+
+            <ul style={{ marginBottom: '1rem', paddingLeft: '1.25rem' }}>
+                <li><strong>Metric Type:</strong> Choose “Market Correlation”.</li>
+                <li><strong>Market Ticker:</strong> Enter the benchmark symbol. </li>
+                <li><strong>Date Range:</strong> Define the window for rolling correlation.
+                The chart shows correlation coefficients from -1 (perfect negative) through +1 (perfect positive), 
+                helping you gauge diversification benefits.</li>
+            </ul>
+          </section>
+
+          <section id="SharpeRatioMatrix" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Sharpe Ratio
+            </h2>
+            <p style={{ marginBottom: '1rem' }}>
+                Sharpe Ratio evaluates risk-adjusted return using total volatility (standard deviation).
+            </p>
+
+            <ul style={{ marginBottom: '1rem', paddingLeft: '1.25rem' }}>
+                <li><strong>Metric Type:</strong> Pick “Sharpe Ratio”.</li>
+                <li><strong>Risk-Free Rate:</strong> Enter the annual risk-free rate. </li>
+                <li><strong>Date Range:</strong> Select the timeframe.
+                The resulting chart plots Sharpe values—higher ratios imply more reward per unit of total risk.</li>
+            </ul>
+          </section>
+
+          <section id="ValueAtRiskAnalysis" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Value at Risk
+            </h2>
+            <p style={{ marginBottom: '1rem' }}>
+                Value at Risk (VaR) estimates your potential loss at a given confidence level.
+            </p>
+
+            <ul style={{ marginBottom: '1rem', paddingLeft: '1.25rem' }}>
+                <li><strong>Metric Type:</strong> Select “Value at Risk”.</li>
+                <li><strong>Confidence Level:</strong> Enter a decimal (e.g. 0.05 for 95% VaR). </li>
+                <li><strong>Date Range:</strong> Choose the period to analyze.
+                You'll see VaR over time, which tells you, for example, “on 5% of days I lost more than X%.”</li>
+            </ul>
+          </section>
+
+          <section id="EfficientFrontierVisualization" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Efficient Frontier
+            </h2>
+            <p style={{ marginBottom: '1rem' }}>
+                Efficient Frontier shows the set of optimal portfolios that offer the highest expected return for each level of risk.
+            </p>
+
+            <ul style={{ marginBottom: '1rem', paddingLeft: '1.25rem' }}>
+                <li><strong>Metric Type:</strong> Choose “Efficient Frontier”.</li>
+                <li><strong>Date Range:</strong> Define your historical window.
+                After applying, you'll see a scatterplot of portfolio points with the frontier curve—use this to find the best trade-off between risk and return.</li>
+            </ul>
+          </section>
+        </div>
       </div>
     </div>
   );
-}
+};
 
 export default Guide;

--- a/client/pages/Guide.tsx
+++ b/client/pages/Guide.tsx
@@ -98,6 +98,7 @@ const Guide: React.FC = () => {
           <section id="portfolio" style={{ marginBottom: '2rem' }}>
             <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
                 Portfolio
+                {/* test */}
             </h2>
                 <p style={{ marginBottom: '1rem' }}>
                 Users can search and select a stock via the top search bar. 

--- a/client/pages/Guide.tsx
+++ b/client/pages/Guide.tsx
@@ -1,159 +1,17 @@
-import React from 'react';
-import Sidebar from '@/components/sidebar';
+import React from "react";
+import Sidebar from "@/components/sidebar"; // Adjust the path to match where Sidebar is located in your project
 
-interface TOCItem { id: string; label: string; }
-interface TableOfContentsProps { items: TOCItem[]; }
-
-const TableOfContents: React.FC<TableOfContentsProps> = ({ items }) => (
-  <nav style={{
-    marginBottom: '1.5rem',
-    padding: '1rem',
-    backgroundColor: '#f9fafb',
-    borderLeft: '4px solid #0070f3', 
-    borderRadius: '4px',
-    boxShadow: '0 2px 4px rgba(0,0,0,0.05)',
-    position: 'sticky',              
-    top: '1rem',
-  }}>
-    <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
-      {items.map(item => (
-        <li key={item.id} style={{ margin: '0.5rem 0' }}>
-          <a
-            href={`#${item.id}`}
-            style={{
-              color: '#0070f3',
-              textDecoration: 'none',
-              fontSize: '1rem',
-              fontWeight: 500,
-            }}
-          >
-            {item.label}
-          </a>
-        </li>
-      ))}
-    </ul>
-  </nav>
-);
-
-const Guide: React.FC = () => {
-  const tocItems: TOCItem[] = [
-    { id: 'login-signup', label: 'Login and SignUp' },
-    { id: 'portfolio',    label: 'Portfolio' },
-    { id: 'top-picks',    label: 'Top Picks' },
-    { id: 'market-news',  label: 'Market News' },
-    { id: 'watchlist',    label: 'Watchlist' },
-    { id: 'community',    label: 'Community' },
-    { id: 'profile',      label: 'Profile' },
-  ];
-
+function Guide() {
   return (
-    <div style={{ display: 'flex', height: '100vh' }}>
+    <div style={{ display: "flex" }}>
       <Sidebar />
-      <div style={{ flex: 1, paddingLeft: '50px' }}>
-        <main style={{
-          flex: 1,
-          display: 'flex',
-          flexDirection: 'column',
-          padding: '2rem',
-          overflowY: 'auto',
-        }}>
-          <h1 style={{ fontSize: '2rem', fontWeight: 'bold', marginBottom: '1.5rem' }}>
-            Guide
-          </h1>
-
-          <TableOfContents items={tocItems} />
-
-          {/* main content */}
-          <section id="login-signup" style={{ marginBottom: '2rem' }}>
-            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
-                Login and SignUp
-            </h2>
-            {/* TODO*/}
-            <p style={{ marginBottom: '1rem' }}>
-                A unified form layout lets users either register or authenticate, with field sets and button labels changing based on mode.
-            </p>
-
-            <h3 style={{ fontSize: '1.25rem', fontWeight: '500', marginBottom: '0.5rem' }}>Sign Up</h3>
-            <ul style={{ marginBottom: '1rem', paddingLeft: '1.25rem' }}>
-                <li><strong>Fields:</strong> First name, last name, email, password</li>
-                <li><strong>Primary Button:</strong> “Sign up” (creates account + confirmation email)</li>
-                <li><strong>OAuth Option:</strong> “Sign up with Google” (one-click registration)</li>
-            </ul>
-
-            <h3 style={{ fontSize: '1.25rem', fontWeight: '500', marginBottom: '0.5rem' }}>Log In</h3>
-            <ul style={{ marginBottom: '1rem', paddingLeft: '1.25rem' }}>
-                <li><strong>Fields:</strong> Email, password</li>
-                <li><strong>Primary Button:</strong> “Log in” (standard email/password auth)</li>
-                <li><strong>OAuth Option:</strong> “Log in with Google” (Google OAuth)</li>
-            </ul>
-
-            <h3 style={{ fontSize: '1.25rem', fontWeight: '500', marginBottom: '0.5rem' }}>Key Functional Points</h3>
-            <ul style={{ paddingLeft: '1.25rem' }}>
-                <li>Inline validation for field errors (e.g. invalid email, weak password)</li>
-                <li>Sticky labels and clear focus states for accessibility</li>
-                <li>Responsive: two-column inputs collapse to single column on narrow screens</li>
-            </ul>
-          </section>
-
-          <section id="portfolio" style={{ marginBottom: '2rem' }}>
-            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
-                Portfolio
-            </h2>
-                <p style={{ marginBottom: '1rem' }}>
-                Users can search and select a stock via the top search bar. 
-                </p>
-                <p style={{ marginBottom: '1rem' }}>
-                the main chart pane then displays the chosen ticker's data.
-                </p>
-
-                <ul style={{ marginBottom: '1rem', paddingLeft: '1.25rem' }}>
-                <li><strong>Main block:</strong> Renders the selected stock's interactive chart.</li>
-                <li><strong>Mini blocks (x5):</strong> Swap any chart into the main pane using the ↔ button.</li>
-                <li><strong>Settings (⚙️):</strong> Adjust metric type, start/end dates, series color, and other metric‑specific parameters per pane.</li>
-                <li><strong>Sync:</strong> User-defined chart configurations automatically sync to the dashboard for consistent display.</li>
-                </ul>
-          </section>
-
-          <section id="top-picks" style={{ marginBottom: '2rem' }}>
-            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
-                Top Picks
-            </h2>
-            {/* TODO*/}
-          </section>
-
-          <section id="market-news" style={{ marginBottom: '2rem' }}>
-            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
-                Market News
-            </h2>
-            {/* TODO*/}
-          </section>
-
-          <section id="watchlist" style={{ marginBottom: '2rem' }}>
-            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
-                Watchlist
-            </h2>
-            {/* TODO*/}
-          </section>
-
-          <section id="community" style={{ marginBottom: '2rem' }}>
-            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
-                Community
-            </h2>
-            {/* TODO*/}
-          </section>
-
-          <section id="profile" style={{ marginBottom: '2rem' }}>
-            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
-                Profile
-            </h2>
-            {/* TODO*/}
-          </section>
-
-          
-        </main>
+      <div style={{ flex: 1, paddingLeft: "50px" }}>
+        {/* Your portfolio page content will go here */}
+        <h1>Market News</h1>
+        <p>This is where you can add your market news content.</p>
       </div>
     </div>
   );
-};
+}
 
 export default Guide;

--- a/client/pages/Help.tsx
+++ b/client/pages/Help.tsx
@@ -1,17 +1,159 @@
-import React from "react";
-import Sidebar from "@/components/sidebar"; // Adjust the path to match where Sidebar is located in your project
+import React from 'react';
+import Sidebar from '@/components/sidebar';
 
-function Help() {
+interface TOCItem { id: string; label: string; }
+interface TableOfContentsProps { items: TOCItem[]; }
+
+const TableOfContents: React.FC<TableOfContentsProps> = ({ items }) => (
+  <nav style={{
+    marginBottom: '1.5rem',
+    padding: '1rem',
+    backgroundColor: '#f9fafb',
+    borderLeft: '4px solid #0070f3', 
+    borderRadius: '4px',
+    boxShadow: '0 2px 4px rgba(0,0,0,0.05)',
+    position: 'sticky',              
+    top: '1rem',
+  }}>
+    <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+      {items.map(item => (
+        <li key={item.id} style={{ margin: '0.5rem 0' }}>
+          <a
+            href={`#${item.id}`}
+            style={{
+              color: '#0070f3',
+              textDecoration: 'none',
+              fontSize: '1rem',
+              fontWeight: 500,
+            }}
+          >
+            {item.label}
+          </a>
+        </li>
+      ))}
+    </ul>
+  </nav>
+);
+
+const Help: React.FC = () => {
+  const tocItems: TOCItem[] = [
+    { id: 'login-signup', label: 'Login and SignUp' },
+    { id: 'portfolio',    label: 'Portfolio' },
+    { id: 'top-picks',    label: 'Top Picks' },
+    { id: 'market-news',  label: 'Market News' },
+    { id: 'watchlist',    label: 'Watchlist' },
+    { id: 'community',    label: 'Community' },
+    { id: 'profile',      label: 'Profile' },
+  ];
+
   return (
-    <div style={{ display: "flex" }}>
+    <div style={{ display: 'flex', height: '100vh' }}>
       <Sidebar />
-      <div style={{ flex: 1, paddingLeft: "50px" }}>
-        {/* Your portfolio page content will go here */}
-        <h1>Help</h1>
-        <p>This is where you can add your HELP page content.</p>
+      <div style={{ flex: 1, paddingLeft: '50px' }}>
+        <main style={{
+          flex: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          padding: '2rem',
+          overflowY: 'auto',
+        }}>
+          <h1 style={{ fontSize: '2rem', fontWeight: 'bold', marginBottom: '1.5rem' }}>
+            Help
+          </h1>
+
+          <TableOfContents items={tocItems} />
+
+          {/* main content */}
+          <section id="login-signup" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Login and SignUp
+            </h2>
+            {/* TODO*/}
+            <p style={{ marginBottom: '1rem' }}>
+                A unified form layout lets users either register or authenticate, with field sets and button labels changing based on mode.
+            </p>
+
+            <h3 style={{ fontSize: '1.25rem', fontWeight: '500', marginBottom: '0.5rem' }}>Sign Up</h3>
+            <ul style={{ marginBottom: '1rem', paddingLeft: '1.25rem' }}>
+                <li><strong>Fields:</strong> First name, last name, email, password</li>
+                <li><strong>Primary Button:</strong> “Sign up” (creates account + confirmation email)</li>
+                <li><strong>OAuth Option:</strong> “Sign up with Google” (one-click registration)</li>
+            </ul>
+
+            <h3 style={{ fontSize: '1.25rem', fontWeight: '500', marginBottom: '0.5rem' }}>Log In</h3>
+            <ul style={{ marginBottom: '1rem', paddingLeft: '1.25rem' }}>
+                <li><strong>Fields:</strong> Email, password</li>
+                <li><strong>Primary Button:</strong> “Log in” (standard email/password auth)</li>
+                <li><strong>OAuth Option:</strong> “Log in with Google” (Google OAuth)</li>
+            </ul>
+
+            <h3 style={{ fontSize: '1.25rem', fontWeight: '500', marginBottom: '0.5rem' }}>Key Functional Points</h3>
+            <ul style={{ paddingLeft: '1.25rem' }}>
+                <li>Inline validation for field errors (e.g. invalid email, weak password)</li>
+                <li>Sticky labels and clear focus states for accessibility</li>
+                <li>Responsive: two-column inputs collapse to single column on narrow screens</li>
+            </ul>
+          </section>
+
+          <section id="portfolio" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Portfolio
+            </h2>
+                <p style={{ marginBottom: '1rem' }}>
+                Users can search and select a stock via the top search bar. 
+                </p>
+                <p style={{ marginBottom: '1rem' }}>
+                the main chart pane then displays the chosen ticker's data.
+                </p>
+
+                <ul style={{ marginBottom: '1rem', paddingLeft: '1.25rem' }}>
+                <li><strong>Main block:</strong> Renders the selected stock's interactive chart.</li>
+                <li><strong>Mini blocks (x5):</strong> Swap any chart into the main pane using the ↔ button.</li>
+                <li><strong>Settings (⚙️):</strong> Adjust metric type, start/end dates, series color, and other metric‑specific parameters per pane.</li>
+                <li><strong>Sync:</strong> User-defined chart configurations automatically sync to the dashboard for consistent display.</li>
+                </ul>
+          </section>
+
+          <section id="top-picks" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Top Picks
+            </h2>
+            {/* TODO*/}
+          </section>
+
+          <section id="market-news" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Market News
+            </h2>
+            {/* TODO*/}
+          </section>
+
+          <section id="watchlist" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Watchlist
+            </h2>
+            {/* TODO*/}
+          </section>
+
+          <section id="community" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Community
+            </h2>
+            {/* TODO*/}
+          </section>
+
+          <section id="profile" style={{ marginBottom: '2rem' }}>
+            <h2 style={{ fontSize: '1.5rem', fontWeight: '600', marginBottom: '0.5rem' }}>
+                Profile
+            </h2>
+            {/* TODO*/}
+          </section>
+
+          
+        </main>
       </div>
     </div>
   );
-}
+};
 
 export default Help;


### PR DESCRIPTION
## Changed

* **New `TableOfContents` component**

  * Fully typed (`TOCItem` / `TableOfContentsProps`)
  * Sticky, styled nav card with left accent bar, rounded corners, drop-shadow

* **Updated `Help` layout**

  * Page title (“Help”) and TOC injected at the top of the content column
  * **Completed content** for two sections:

  1. **Login and SignUp**

     * Unified overview paragraph
     * Sign-up / Log-in subsections with field lists, button labels, OAuth options
     * Key functional points (validation, accessibility, responsiveness)
  2. **Portfolio**

     * Description of top search bar selection flow
     * Main chart pane + five mini-pane swap controls
     * Settings (metric type, date range, color, etc.) and dashboard sync behavior

  * **Scaffolded** remaining sections (`Top Picks`, `Market News`, `Watchlist`, `Community`, `Profile`) for future content

* **New `Guide` page**

  * **Layout**: Similar two-column design – sticky TOC on the left, scrollable content on the right
  * **General section** explaining how to open the metrics modal and apply settings
  * **Beta Analysis** and **Alpha Comparison** sections fully documented, guiding users through:

    * Selecting metric type
    * Filling in additional fields (benchmark ticker, risk-free rate)
    * Interpreting the resulting chart
  * **Scaffolded** content blocks for all other metrics (`Max Drawdown`, `Cumulative Return`, `Sortino Ratio`, `Market Correlation`, `Sharpe Ratio`, `Value at Risk`, `Efficient Frontier`)

---

## Next steps

* Flesh out the remaining **Help** and **Guide** sections with real screenshots and examples
* Add unit/UI tests for `TableOfContents`, anchor links, and modal interactions
* Hook up real data-driven examples in both pages

---

**Related issue:** #60
