### PR TITLE
Metrics now get database data and connect with the backend

### DIFF
--- a/client/components/StockCardComponent.tsx
+++ b/client/components/StockCardComponent.tsx
@@ -6,6 +6,7 @@ import LineGraph from './linegraph';
 import GraphSettingsModal, {GraphSettings} from './graphSettingsModal';
 import { fetchMetrics, MetricsResponse } from './fetchMetrics';
 import { CardSettings } from '@/pages/dashboardView';
+import ScatterPlotGraph from './scatterplot';
 
 type OHLCData = {
     date: string;
@@ -268,6 +269,25 @@ const StockChartCard: React.FC<StockChartCardProps> = ({
           mainColor={barColor}
         />
       );
+    
+    case 'efficientfrontiervisualization':
+      return (
+      <ScatterPlotGraph
+        data={chartData.flatMap((data) => {
+          const portfolio = data.series.portfolio;
+          if (!portfolio) return [];
+
+          return portfolio.returns.map((point, i) => ({
+            risk: portfolio.risks[i],
+            return: portfolio.returns[i],
+            sharpe: portfolio.sharpe_ratios[i],
+          }));
+        })}
+        width={dimensions.width - 32}
+        height={dimensions.height - 90}
+        mainColor={barColor}
+      />
+    );
     /*
     case 'betaanalysis':
     case 'alphacomparison':

--- a/client/components/StockCardComponent.tsx
+++ b/client/components/StockCardComponent.tsx
@@ -265,6 +265,7 @@ const StockChartCard: React.FC<StockChartCardProps> = ({
           )}
           width={dimensions.width - 32}
           height={dimensions.height - 90}
+          mainColor={barColor}
         />
       );
     /*

--- a/client/components/StockCardComponent.tsx
+++ b/client/components/StockCardComponent.tsx
@@ -179,9 +179,8 @@ const StockChartCard: React.FC<StockChartCardProps> = ({
 
     const fetchAllData = async () => {
 
-      const data = selectedStocks.map(ticker =>
-        fetchMetrics({
-          tickers: [ticker],
+      const allData = await fetchMetrics({
+          tickers: selectedStocks,
           settings: {
             metricType: metricType as any,
             metricParams: {
@@ -189,12 +188,10 @@ const StockChartCard: React.FC<StockChartCardProps> = ({
               endDate: dateRange.end,
             },
             stockColour: barColor
-          }
-        })
-      );
+          },
+        });
 
-      const allData = await Promise.all(data);
-      setChartData(allData);
+      setChartData([allData]);
     };
 
     fetchAllData();

--- a/client/components/StockCardComponent.tsx
+++ b/client/components/StockCardComponent.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { Box, Button, Select, MenuItem, SelectChangeEvent } from '@mui/material';
 import OHLCChart from './ohlc';
 import BarGraph from './bargraph';
+import LineGraph from './linegraph';
 import GraphSettingsModal, {GraphSettings} from './graphSettingsModal';
 import { fetchMetrics, MetricsResponse } from './fetchMetrics';
 import { CardSettings } from '@/pages/dashboardView';
@@ -167,15 +168,6 @@ const StockChartCard: React.FC<StockChartCardProps> = ({
     });
 
     onActivate(index);
-
-    if (selectedStocks.length === 0) {
-      return;
-    }
-
-    // Fetch data with the new settings
-    const data = selectedStocks.map(ticker => fetchMetrics({ ticker, settings}));
-    const allData = await Promise.all(data);
-    setChartData(allData);
   };
 
   useEffect(() => {
@@ -237,6 +229,23 @@ const StockChartCard: React.FC<StockChartCardProps> = ({
             height={dimensions.height - 90}
           />
         );
+    case 'betaanalysis':
+    case 'alphacomparison':
+    case 'sortinoratiovisualization':
+    case 'sharperatiomatrix':
+    case 'volatilityanalysis':
+    case 'valueatriskanalysis':
+      return (
+        <BarGraph
+          data={chartData.map(data => ({
+            label: data.ticker,
+            value: data.series.singleValue || 0
+          }))}
+          width={dimensions.width - 32}
+          height={dimensions.height - 90}
+          barColor={barColor}
+        />
+      )
     /*
     case 'betaanalysis':
     case 'alphacomparison':

--- a/client/components/StockCardComponent.tsx
+++ b/client/components/StockCardComponent.tsx
@@ -181,7 +181,7 @@ const StockChartCard: React.FC<StockChartCardProps> = ({
 
       const data = selectedStocks.map(ticker =>
         fetchMetrics({
-          ticker, 
+          tickers: [ticker],
           settings: {
             metricType: metricType as any,
             metricParams: {
@@ -229,6 +229,7 @@ const StockChartCard: React.FC<StockChartCardProps> = ({
             height={dimensions.height - 90}
           />
         );
+
     case 'betaanalysis':
     case 'alphacomparison':
     case 'sortinoratiovisualization':
@@ -237,15 +238,36 @@ const StockChartCard: React.FC<StockChartCardProps> = ({
     case 'valueatriskanalysis':
       return (
         <BarGraph
-          data={chartData.map(data => ({
-            label: data.ticker,
-            value: data.series.singleValue || 0
-          }))}
+          data={chartData.flatMap(data => {
+            const tickers = data.tickers || [];
+            const singleValue = data.series.singleValue || {};
+            return tickers.map(t => ({
+              label: t,
+              value: singleValue[t]
+            }));
+          })}
           width={dimensions.width - 32}
           height={dimensions.height - 90}
           barColor={barColor}
         />
-      )
+      );
+    
+    case 'marketcorrelationanalysis':
+    case 'cumulativereturncomparison':
+    case 'maxdrawdownanalysis':
+      return (
+        <LineGraph
+          data={chartData.flatMap((data, index) => ({
+            ticker: data.tickers[0],
+            values: (data.series.timeSeries?.[data.tickers[0]] || []).map(point => ({
+              date: new Date(point.date),
+              value: point.value
+            }))
+          }))}
+          width={dimensions.width - 32}
+          height={dimensions.height - 90}
+        />
+      );
     /*
     case 'betaanalysis':
     case 'alphacomparison':

--- a/client/components/StockCardComponent.tsx
+++ b/client/components/StockCardComponent.tsx
@@ -239,8 +239,26 @@ const StockChartCard: React.FC<StockChartCardProps> = ({
         );
     /*
     case 'betaanalysis':
+    case 'alphacomparison':
+    case 'sortinoratiovisualization':
+    case 'sharperatiomatrix':
+    case 'volatilityanalysis':
+    case 'valueatriskanalysis':
       Should be displayed as a bar chart.
-      Potentially regression line instead based on each day but calculate_beta() will need to be changed
+      Potentially regression line but related functions will need to be changed to calculate metric per day instead of overall
+    
+    case 'marketcorrelationanalysis':
+      This returns a series of values per day
+      Should be a line chart
+      Potentially a bar or heatmap if changed to overall stock
+
+    case 'maxdrawdownanalysis':
+    case 'cumulativereturncomparison':
+      This returns a series of values per day
+      Should be a line chart
+    
+    case 'efficientfrontieranalysis':
+      This should be displayed as a scatter plot.
     */
 
     default:

--- a/client/components/StockCardComponent.tsx
+++ b/client/components/StockCardComponent.tsx
@@ -254,13 +254,15 @@ const StockChartCard: React.FC<StockChartCardProps> = ({
     case 'maxdrawdownanalysis':
       return (
         <LineGraph
-          data={chartData.flatMap((data, index) => ({
-            ticker: data.tickers[0],
-            values: (data.series.timeSeries?.[data.tickers[0]] || []).map(point => ({
-              date: new Date(point.date),
-              value: point.value
+          data={chartData.flatMap((data) =>
+            data.tickers.map(ticker => ({
+              ticker: ticker,
+              values: (data.series.timeSeries?.[ticker] || []).map(point => ({
+                date: new Date(point.date),
+                value: point.value
+              }))
             }))
-          }))}
+          )}
           width={dimensions.width - 32}
           height={dimensions.height - 90}
         />

--- a/client/components/bargraph.tsx
+++ b/client/components/bargraph.tsx
@@ -39,13 +39,9 @@ interface BarGraphProps {
 
         if (values.length === 1) {
             const val = values[0];
-            if (val >= 0){
-                yMin = 0;
-                yMax = val + val * 0.1; // 10% padding
-            } else {
-                yMin = val - Math.abs(val) * 0.1;
-                yMax = 0;
-            }
+            const range = Math.abs(val) * 1.1; //10% padding
+            yMin = -range;
+            yMax = range;
         } else {
             yMin = minValue - (maxValue - minValue) * 0.1;
             yMax = maxValue + (maxValue - minValue) * 0.1;
@@ -81,11 +77,12 @@ interface BarGraphProps {
     const bars = g.selectAll('.bar')
         .data(data);
 
+    const zeroY = yScale(0);
     bars.enter()
         .append("rect")
         .attr("class", "bar")
         .attr("x", (d) => xScale(d.label)!)
-        .attr("y", graphHeight) // Start from the bottom
+        .attr("y", zeroY) // Start from the bottom
         .attr("width", xScale.bandwidth())
         .attr("height", 0) // Start with height 0
         .attr("fill", (d, i) => i === 0 ? barColor : lineColors[(i-1) % lineColors.length])
@@ -104,12 +101,12 @@ interface BarGraphProps {
         })
         .transition() // Animate the bars
         .duration(800)
-        .attr("y", (d) => yScale(d.value))
-        .attr("height", (d) => graphHeight - yScale(d.value));
+        .attr("y", (d) => d.value >= 0 ? yScale(d.value) : zeroY)
+        .attr("height", (d) => Math.abs(yScale(d.value) - zeroY));
 
     // Append axes
     g.append('g')
-        .attr('transform', `translate(0,${graphHeight})`)
+        .attr('transform', `translate(0,${yScale(0)})`)
         .call(d3.axisBottom(xScale));
     g.append('g')
         .call(d3.axisLeft(yScale));

--- a/client/components/bargraph.tsx
+++ b/client/components/bargraph.tsx
@@ -32,12 +32,25 @@ interface BarGraphProps {
         const values = data.map((d) => d.value);
         const minValue = d3.min(values)!;
         const maxValue = d3.max(values)!;
-        const paddingFactor = 0.1; // So the smallest isnt on the x-axis looking missing
-        const paddedMin = minValue - (maxValue - minValue) * paddingFactor;
-        const paddedMax = maxValue + (maxValue - minValue) * paddingFactor;
+
+        let yMin: number, yMax: number;
+
+        if (values.length === 1) {
+            const val = values[0];
+            if (val >= 0){
+                yMin = 0;
+                yMax = val + val * 0.1; // 10% padding
+            } else {
+                yMin = val - Math.abs(val) * 0.1;
+                yMax = 0;
+            }
+        } else {
+            yMin = minValue - (maxValue - minValue) * 0.1;
+            yMax = maxValue + (maxValue - minValue) * 0.1;
+        }
 
         const yScale = d3.scaleLinear()
-            .domain([paddedMin, paddedMax]).nice()
+            .domain([yMin, yMax]).nice()
             .range([graphHeight, 0]);
   
         const svg = d3.select(svgRef.current)

--- a/client/components/bargraph.tsx
+++ b/client/components/bargraph.tsx
@@ -35,21 +35,13 @@ interface BarGraphProps {
         const minValue = d3.min(values)!;
         const maxValue = d3.max(values)!;
 
-        let yMin: number, yMax: number;
-
-        if (values.length === 1) {
-            const val = values[0];
-            const range = Math.abs(val) * 1.1; //10% padding
-            yMin = -range;
-            yMax = range;
-        } else {
-            yMin = minValue - (maxValue - minValue) * 0.1;
-            yMax = maxValue + (maxValue - minValue) * 0.1;
-        }
+        const yMin = Math.min(0, minValue - (maxValue - minValue) * 0.1);
+        const yMax = Math.max(0, maxValue + (maxValue - minValue) * 0.1);
 
         const yScale = d3.scaleLinear()
-            .domain([yMin, yMax]).nice()
-            .range([graphHeight, 0]);
+            .domain([yMin, yMax])
+            .range([graphHeight, 0])
+            .nice();
   
         const svg = d3.select(svgRef.current)
         .attr('width', width)

--- a/client/components/bargraph.tsx
+++ b/client/components/bargraph.tsx
@@ -28,8 +28,16 @@ interface BarGraphProps {
         // scales 
         const xScale = d3.scaleBand().domain(data.map((d) => d.label))
             .range([0, graphWidth]).padding(0.2);
+        
+        const values = data.map((d) => d.value);
+        const minValue = d3.min(values)!;
+        const maxValue = d3.max(values)!;
+        const paddingFactor = 0.1; // So the smallest isnt on the x-axis looking missing
+        const paddedMin = minValue - (maxValue - minValue) * paddingFactor;
+        const paddedMax = maxValue + (maxValue - minValue) * paddingFactor;
+
         const yScale = d3.scaleLinear()
-            .domain([0, d3.max(data, (d) => d.value)!]).nice()
+            .domain([paddedMin, paddedMax]).nice()
             .range([graphHeight, 0]);
   
         const svg = d3.select(svgRef.current)

--- a/client/components/bargraph.tsx
+++ b/client/components/bargraph.tsx
@@ -7,13 +7,15 @@ interface BarGraphProps {
         width?: number;
         height?: number;
         barColor?: string;
+        lineColors?: string[];
     }
   
     const BarGraph: React.FC<BarGraphProps> = ({
         data,
         width = 500,
         height = 300,
-        barColor = '#800080',
+        barColor = '#fc03d7',
+        lineColors = ['#FF0000', '#008000', '#0000FF']
     }) => {
     const svgRef = useRef<SVGSVGElement | null>(null);
     const tooltipRef = useRef<HTMLDivElement | null>(null);
@@ -86,7 +88,7 @@ interface BarGraphProps {
         .attr("y", graphHeight) // Start from the bottom
         .attr("width", xScale.bandwidth())
         .attr("height", 0) // Start with height 0
-        .attr("fill", barColor)
+        .attr("fill", (d, i) => i === 0 ? barColor : lineColors[(i-1) % lineColors.length])
         .on("mouseover", function (event, d) {
             tooltip
             .style("display", "block")

--- a/client/components/fetchMetrics.tsx
+++ b/client/components/fetchMetrics.tsx
@@ -70,6 +70,7 @@ function formatMetricsResponse(ticker: string, metricType: string, data: any): M
     case 'SortinoRatioVisualization':
     case 'SharpeRatioMatrix':
     case 'ValueAtRiskAnalysis':
+    case 'VolatilityAnalysis':
       response.series.singleValue = data[ticker]
       break;
     

--- a/client/components/graphSettingsModal.tsx
+++ b/client/components/graphSettingsModal.tsx
@@ -22,6 +22,7 @@ export type MetricType =
   | 'SortinoRatioVisualization'
   | 'MarketCorrelationAnalysis'
   | 'SharpeRatioMatrix'
+  | 'VolatilityAnalysis'
   | 'ValueAtRiskAnalysis'
   | 'EfficientFrontierVisualization';
 
@@ -77,7 +78,7 @@ const GraphSettingsModal: React.FC<GraphSettingsModalProps> = ({ open, onClose, 
         stockColour
       };
 
-      
+    
       // Pass all Settings to the parent component
       onApply(settings);
       onClose();
@@ -108,6 +109,7 @@ const GraphSettingsModal: React.FC<GraphSettingsModalProps> = ({ open, onClose, 
                 <MenuItem value="SortinoRatioVisualization">Sortino Ratio</MenuItem>
                 <MenuItem value="MarketCorrelationAnalysis">Market Correlation</MenuItem>
                 <MenuItem value="SharpeRatioMatrix">Sharpe Ratio</MenuItem>
+                <MenuItem value="VolatilityAnalysis">Volatility</MenuItem>
                 <MenuItem value="ValueAtRiskAnalysis">Value at Risk</MenuItem>
                 <MenuItem value="EfficientFrontierVisualization">Efficient Frontier</MenuItem>
               </Select>

--- a/client/components/graphSettingsModal.tsx
+++ b/client/components/graphSettingsModal.tsx
@@ -58,7 +58,9 @@ const GraphSettingsModal: React.FC<GraphSettingsModalProps> = ({ open, onClose, 
 
     // After user clicks, collect parameters and callback
     const handleApply = () => {
+      
       const params: GraphSettings['metricParams'] = { startDate, endDate };
+      
       if (metricType === 'BetaAnalysis' || metricType === 'MarketCorrelationAnalysis') {
         params.marketTicker = marketTicker;
       }
@@ -69,9 +71,21 @@ const GraphSettingsModal: React.FC<GraphSettingsModalProps> = ({ open, onClose, 
         params.confidenceLevel = confidenceLevel;
       }
 
+      const settings: GraphSettings = {
+        metricType,
+        metricParams: params,
+        stockColour
+      };
+
+      
       // Pass all Settings to the parent component
-      onApply({ metricType, metricParams: params, stockColour});
+      onApply(settings);
       onClose();
+    };
+
+    const handleMetricTypeChange = (event: any) => {
+      const newMetricType = event.target.value as MetricType;
+      setMetricType(newMetricType);
     };
   
 
@@ -85,7 +99,7 @@ const GraphSettingsModal: React.FC<GraphSettingsModalProps> = ({ open, onClose, 
                 labelId="metric-type-label"
                 value={metricType}
                 label="Metric Type"
-                onChange={(e) => setMetricType(e.target.value as MetricType)}
+                onChange={handleMetricTypeChange}
               >
                 <MenuItem value="BetaAnalysis">Beta Analysis</MenuItem>
                 <MenuItem value="AlphaComparison">Alpha Comparison</MenuItem>

--- a/client/components/linegraph.tsx
+++ b/client/components/linegraph.tsx
@@ -67,7 +67,7 @@ interface LineGraphProps {
 
     // Append line paths for each series
     data.forEach((series, i) => {
-        const lineColor = i === 0 ? mainColor : lineColors[i % lineColors.length];
+        const lineColor = i === 0 ? mainColor : lineColors[(i-1) % lineColors.length];
         g.append('path')
             .datum(series.values)
             .attr('fill', 'none')

--- a/client/components/linegraph.tsx
+++ b/client/components/linegraph.tsx
@@ -5,6 +5,7 @@ interface LineGraphProps {
     data: {ticker: string; values: { date: Date; value: number }[]}[];
     width?: number;
     height?: number;
+    mainColor?: string;
     lineColors?: string[];
 }
 
@@ -12,7 +13,8 @@ interface LineGraphProps {
     data,
     width = 500,
     height = 300,
-    lineColors = ['#800080', '#FF0000', '#008000', '#0000FF'],
+    mainColor = '#fc03d7',
+    lineColors = ['#FF0000', '#008000', '#0000FF'],
     }) => {
     const svgRef = useRef<SVGSVGElement | null>(null);
     const tooltipRef = useRef<HTMLDivElement | null>(null);
@@ -65,7 +67,7 @@ interface LineGraphProps {
 
     // Append line paths for each series
     data.forEach((series, i) => {
-        const lineColor = lineColors[i % lineColors.length];
+        const lineColor = i === 0 ? mainColor : lineColors[i % lineColors.length];
         g.append('path')
             .datum(series.values)
             .attr('fill', 'none')

--- a/client/components/linegraph.tsx
+++ b/client/components/linegraph.tsx
@@ -2,20 +2,21 @@ import * as d3 from 'd3';
 import React, { useState, useRef, useEffect } from 'react';
 
 interface LineGraphProps {
-    data: { date: Date; value: number }[];
+    data: {ticker: string; values: { date: Date; value: number }[]}[];
     width?: number;
     height?: number;
-    lineColor?: string;
+    lineColors?: string[];
 }
 
     const LineGraph: React.FC<LineGraphProps> = ({
     data,
     width = 500,
     height = 300,
-    lineColor = '#800080',
+    lineColors = ['#800080', '#FF0000', '#008000', '#0000FF'],
     }) => {
     const svgRef = useRef<SVGSVGElement | null>(null);
     const tooltipRef = useRef<HTMLDivElement | null>(null);
+
     useEffect(() => {
     if (!data.length) return;
 
@@ -28,15 +29,18 @@ interface LineGraphProps {
     const graphWidth = width - l - r;
     const graphHeight = height - t - b;
 
+    const allValues = data.flatMap(d => d.values);
+
     // Create scales for x (time) and y (values)
     const xScale = d3
         .scaleTime()
-        .domain(d3.extent(data, (d) => d.date) as [Date, Date])
+        .domain(d3.extent(allValues, (d) => d.date) as [Date, Date])
         .range([0, graphWidth]);
 
+    const yExtent = d3.extent(allValues, (d) => d.value) as [number, number];
     const yScale = d3
         .scaleLinear()
-        .domain([0, d3.max(data, (d) => d.value)!])
+        .domain(yExtent)
         .range([graphHeight, 0]);
 
     // Create line generator function
@@ -59,13 +63,16 @@ interface LineGraphProps {
     // Add graph group with margins
     const g = svg.append('g').attr('transform', `translate(${l},${t})`);
 
-    // Append line path
-    g.append('path')
-        .datum(data)
-        .attr('fill', 'none')
-        .attr('stroke', lineColor)
-        .attr('stroke-width', 2)
+    // Append line paths for each series
+    data.forEach((series, i) => {
+        const lineColor = lineColors[i % lineColors.length];
+        g.append('path')
+            .datum(series.values)
+            .attr('fill', 'none')
+            .attr('stroke', lineColor)
+            .attr('stroke-width', 2)
         .attr('d', line);
+    });
 
     // Add X Axis (bottom)
     g.append('g')
@@ -106,7 +113,8 @@ interface LineGraphProps {
         const dateAtMouse = xScale.invert(mouseX - l); // Get the date based on mouse position
 
         // Find the closest data point to the mouse position
-        const closestPoint = data.reduce((a, b) =>
+        const allPoints = data.flatMap(series => series.values)
+        const closestPoint = allPoints.reduce((a, b) =>
             Math.abs(+a.date - +dateAtMouse) < Math.abs(+b.date - +dateAtMouse) ? a : b
         );
 
@@ -122,7 +130,7 @@ interface LineGraphProps {
         tooltip.style('display', 'none');
         });
 
-    }, [data, width, height, lineColor]);
+    }, [data, width, height, lineColors]);
 
     return (
     <>

--- a/client/components/scatterplot.tsx
+++ b/client/components/scatterplot.tsx
@@ -6,7 +6,6 @@ interface ScatterPlotProps {
     width?: number;
     height?: number;
     mainColor?: string;
-    lineColors?: string[];
 }
 
 const ScatterPlotGraph: React.FC<ScatterPlotProps> = ({
@@ -14,7 +13,6 @@ const ScatterPlotGraph: React.FC<ScatterPlotProps> = ({
     width = 500,
     height = 300,
     mainColor = '#fc03d7',
-    lineColors = ['#FF0000', '#008000', '#0000FF'],
 }) => {
 
     const svgRef = useRef<SVGSVGElement | null>(null);
@@ -113,7 +111,7 @@ const ScatterPlotGraph: React.FC<ScatterPlotProps> = ({
         .on('mouseout', () => {
             tooltip.style('display', 'none');
         });
-        }, [data, width, height, mainColor, lineColors]);
+        }, [data, width, height, mainColor]);
 
         return (
             <>

--- a/client/components/scatterplot.tsx
+++ b/client/components/scatterplot.tsx
@@ -1,0 +1,126 @@
+import * as d3 from 'd3';
+import React, { useState, useRef, useEffect } from 'react';
+
+interface ScatterPlotProps {
+    data: {risk: number; return: number; sharpe?: number }[];
+    width?: number;
+    height?: number;
+    mainColor?: string;
+    lineColors?: string[];
+}
+
+const ScatterPlotGraph: React.FC<ScatterPlotProps> = ({
+    data,
+    width = 500,
+    height = 300,
+    mainColor = '#fc03d7',
+    lineColors = ['#FF0000', '#008000', '#0000FF'],
+}) => {
+
+    const svgRef = useRef<SVGSVGElement | null>(null);
+    const tooltipRef = useRef<HTMLDivElement | null>(null);
+    
+    useEffect(() => {
+    if (!data.length) return;
+
+    // Set up margins and graph dimensions
+    const t = 30;
+    const r = 30;
+    const b = 50;
+    const l = 50;
+    const graphWidth = width - l - r;
+    const graphHeight = height - t - b;    
+    
+    const svg = d3
+        .select(svgRef.current)
+        .attr('width', width)
+        .attr('height', height);
+    
+    svg.selectAll('*').remove();
+
+    // Set background color
+    svg.append('rect')
+        .attr('width', width)
+        .attr('height', height)
+        .attr('fill', '#FFFFFF');
+
+
+    const g = svg.append('g').attr('transform', `translate(${l}, ${t})`);
+    
+    const minY = d3.min(data, d => d.return)!;
+    const maxY = d3.max(data, d => d.return)!;
+    const absY = Math.max(Math.abs(minY), Math.abs(maxY));
+
+    // Create scales
+    const xScale = d3
+        .scaleLinear()
+        .domain(d3.extent(data, d => d.risk) as [number, number])
+        .nice()
+        .range([0, graphWidth]);
+
+    const yScale = d3
+        .scaleLinear()
+        .domain([-absY, absY])
+        .nice()
+        .range([graphHeight, 0]);
+
+    g.append('g')
+        .attr('transform', `translate(0, ${yScale(0)})`)
+        .call(d3.axisBottom(xScale));
+    g.append('g')
+        .call(d3.axisLeft(yScale));
+
+    g.append('text')
+        .attr('x', graphWidth / 2)
+        .attr('y', graphHeight + b - 10)
+        .attr('text-anchor', 'middle')
+        .text('Risk');
+
+    g.append('text')
+        .attr('x', -graphHeight / 2)
+        .attr('y', -l + 15)
+        .attr('text-anchor', 'middle')
+        .attr('transform', 'rotate(-90)')
+        .text('Return');
+
+    // Tooltip setup
+    const tooltip = d3.select(tooltipRef.current)
+        .style('position', 'absolute')
+        .style('background', '#fff')
+        .style('padding', '5px')
+        .style('display', 'none')
+        .style('pointer-events', 'none');
+       
+
+    g.selectAll('circle')
+        .data(data)
+        .enter()
+        .append('circle')
+        .attr('cx', d => xScale(d.risk))
+        .attr('cy', d => yScale(d.return))
+        .attr('r', 5)
+        .attr('fill', mainColor)
+        .on('mouseover', (event, d) => {
+            tooltip
+                .style('display', 'block')
+                .html(`Risk: ${d.risk}<br>Return: ${d.return}<br>Sharpe: ${d.sharpe || 'N/A'}`);
+        })
+        .on('mousemove', (event) => {
+            tooltip
+                .style('left', `${event.pageX + 10}px`)
+                .style('top', `${event.pageY - 28}px`);
+        })
+        .on('mouseout', () => {
+            tooltip.style('display', 'none');
+        });
+        }, [data, width, height, mainColor, lineColors]);
+
+        return (
+            <>
+                <svg ref={svgRef}></svg>
+                <div ref={tooltipRef}></div>
+            </>
+        );
+    };
+
+export default ScatterPlotGraph;

--- a/client/pages/dashboardView.tsx
+++ b/client/pages/dashboardView.tsx
@@ -1,5 +1,3 @@
-// pages/dashboardView.tsx
-
 import React, {useEffect, useState} from 'react';
 // @ts-ignore
 import Sidebar from '@/components/sidebar';
@@ -22,11 +20,12 @@ import supabase from "@/components/supabase";
 import OHLCChart from '@/components/ohlc';
 import { Select, SelectItem } from "@nextui-org/react";
 import StockChartCard, { stockDataMap } from '@/components/StockCardComponent';
+import { MetricType } from '@/components/graphSettingsModal';
 
 export interface CardSettings {
     barColor: string;
     dateRange: { start: string; end: string };
-    metricType: string;
+    metricType: MetricType;
     graphMade: boolean;
 }
 
@@ -38,7 +37,7 @@ const DashboardView: React.FC = () => {
 
     // global time range to initialize and pass to each card
     const [globalStart, setGlobalStart] = useState<string>(() => {
-        // initialize to “now” in local ISO format YYYY‑MM‑DDThh:mm
+        // initialize to "now" in local ISO format YYYY‑MM‑DDThh:mm
         const tzOffset = new Date().getTimezoneOffset() * 60000;
         return new Date(Date.now() - tzOffset).toISOString().slice(0, 16);
     });
@@ -49,7 +48,7 @@ const DashboardView: React.FC = () => {
             () => ({
                 barColor: '#fc03d7', 
                 dateRange: {start: globalStart, end: globalEnd},
-                metricType: 'BetaAnalysis',
+                metricType: 'BetaAnalysis' as MetricType,
                 graphMade: false
             })
         )
@@ -118,7 +117,7 @@ const DashboardView: React.FC = () => {
         });
     };
 
-    const handleCardSettingsUpdate = (index: number, settings: CardSettings) => {
+    const handleCardSettingsUpdate = (index: number, settings: Partial<CardSettings>) => {
         setCardSettings(prev => {
             const updated = [...prev];
             updated[index] = {...updated[index], ...settings};

--- a/server/src/metrics.py
+++ b/server/src/metrics.py
@@ -4,6 +4,7 @@
 import yfinance as yf   # Used to fetch stock data from Yahoo Finance
 import numpy as np      # Used for numerical calculations
 import pandas as pd     # Used for data manipulation
+import matplotlib.pyplot as plt
 
 # Function to fetch full stock data
 def fetch_stock_data(stock_tickers, start_date, end_date):
@@ -57,7 +58,6 @@ def calculate_beta(stock_tickers, market_ticker, start_date, end_date):
     
     # Extract adjusted close prices
     adj_close = data.xs('Adj Close', level=1, axis=1)
-    print(adj_close.columns.to_list())
 
     # Calculate daily returns for stocks and market
     stock_returns = adj_close[stock_tickers].pct_change().dropna()
@@ -105,7 +105,6 @@ def calculate_alpha(stock_tickers, market_ticker, start_date, end_date, risk_fre
     # Fetch data for stocks and market
     data = fetch_stock_data(stock_tickers + [market_ticker], start_date, end_date)
     adj_close = data.xs('Adj Close', level=1, axis=1)
-    print(f"Adjusted Close Columns: {adj_close.columns.to_list()}")
     
     # Calculate daily returns
     stock_returns = adj_close[stock_tickers].pct_change().dropna()
@@ -166,7 +165,7 @@ def calculate_drawdown(stock_tickers, start_date, end_date):
         drawdown = (adj_close[ticker] - cumulative_max) / cumulative_max
         
         drawdowns[ticker] = drawdown
-    
+
     return drawdowns
 
 # Function to calculate Cumulative Return
@@ -412,7 +411,13 @@ def calculate_efficient_frontier(stock_tickers, start_date, end_date, num_portfo
         results['risks'].append(portfolio_risk)
         results['sharpe_ratios'].append(sharpe_ratio)
 
-    
+    # plt.scatter(results['risks'], results['returns'], c=results['sharpe_ratios'], cmap='viridis')
+    # plt.xlabel('Risks')
+    # plt.ylabel('Return')
+    # plt.title('Efficient Frontier')
+    # plt.colorbar(label='Sharpe Ratio')
+    # plt.show()
+
     return results
 
 # Function to calculate Treynor Ratio

--- a/server/src/metrics.py
+++ b/server/src/metrics.py
@@ -57,7 +57,8 @@ def calculate_beta(stock_tickers, market_ticker, start_date, end_date):
     
     # Extract adjusted close prices
     adj_close = data.xs('Adj Close', level=1, axis=1)
-    
+    print(adj_close.columns.to_list())
+
     # Calculate daily returns for stocks and market
     stock_returns = adj_close[stock_tickers].pct_change().dropna()
     market_returns = adj_close[market_ticker].pct_change().dropna()
@@ -104,6 +105,7 @@ def calculate_alpha(stock_tickers, market_ticker, start_date, end_date, risk_fre
     # Fetch data for stocks and market
     data = fetch_stock_data(stock_tickers + [market_ticker], start_date, end_date)
     adj_close = data.xs('Adj Close', level=1, axis=1)
+    print(f"Adjusted Close Columns: {adj_close.columns.to_list()}")
     
     # Calculate daily returns
     stock_returns = adj_close[stock_tickers].pct_change().dropna()
@@ -117,6 +119,7 @@ def calculate_alpha(stock_tickers, market_ticker, start_date, end_date, risk_fre
     alphas = {}
     for ticker in stock_returns.columns:
         # Calculate the average annualized return for the stock
+
         stock_avg_return = stock_returns[ticker].mean() * 252  # 252 trading days in a year
         
         # Calculate the average annualized return for the market

--- a/server/src/metrics.py
+++ b/server/src/metrics.py
@@ -265,6 +265,7 @@ def calculate_correlation_with_market(stock_tickers, market_ticker, start_date, 
         rolling_corr = stock_returns[ticker].rolling(window=21).corr(market_returns)
         
         correlations[ticker] = rolling_corr
+        print(correlations) #This returns NaN. Need to look into why
     
     return correlations
 
@@ -407,6 +408,7 @@ def calculate_efficient_frontier(stock_tickers, start_date, end_date, num_portfo
         results['returns'].append(portfolio_return)
         results['risks'].append(portfolio_risk)
         results['sharpe_ratios'].append(sharpe_ratio)
+
     
     return results
 

--- a/server/src/server.py
+++ b/server/src/server.py
@@ -1,5 +1,6 @@
 from flask import Flask, jsonify, request
 from flask_cors import CORS
+import traceback
 from src.stocks import sanitiseStockJson
 from src.metrics import (
     fetch_stock_data,
@@ -127,6 +128,7 @@ def create_app():
                         if ticker in result.columns.get_level_values(0):
                             ohlc_data.append({
                                 'date': date,
+                                'ticker': ticker,
                                 'open': result[(ticker, 'Open')].loc[date],
                                 'high': result[(ticker, 'High')].loc[date],
                                 'low': result[(ticker, 'Low')].loc[date],
@@ -181,6 +183,7 @@ def create_app():
                 return jsonify({"error": f"Unknown metric type: {metric_type}"}), 400
                 
         except Exception as e:
+            traceback.print_exc()
             return jsonify({"error": str(e)}), 500
 
     @app.route("/api/betaanalysis", methods=['GET'])

--- a/server/src/server.py
+++ b/server/src/server.py
@@ -109,42 +109,120 @@ def create_app():
         # return jsonify(fixed_data)
         # return jsonify(stock_data_json)
 
-    @app.route("/api/beta", methods=['GET'])
+    @app.route("/api/metrics/<metric_type>", methods=['POST'])
+    def get_metric(metric_type):
+        try:
+            data = request.json
+            stock_tickers = data.get('stock_tickers', [])
+            start_date = data.get('start_date', '2023-01-01')
+            end_date = data.get('end_date', '2024-01-01')
+            market_ticker = data.get('market_ticker', 'SPY')
+            risk_free_rate = data.get('risk_free_rate', 0.01)
+            confidence_level = data.get('confidence_level', 0.05)
+            
+            if not stock_tickers:
+                return jsonify({"error": "stock_tickers is required"}), 400
+            
+            if metric_type == 'ohlc':
+                result = fetch_stock_data(stock_tickers, start_date, end_date)
+                ohlc_data = []
+                for date in result.index:
+                    for ticker in stock_tickers:
+                        if ticker in result.columns.get_level_values(0):
+                            ohlc_data.append({
+                                'date': date,
+                                'open': result[(ticker, 'Open')].loc[date],
+                                'high': result[(ticker, 'High')].loc[date],
+                                'low': result[(ticker, 'Low')].loc[date],
+                                'close': result[(ticker, 'Close')].loc[date],
+                            })
+                return jsonify({"ohlc": ohlc_data})
+                
+            elif metric_type == 'betaanalysis':
+                result = calculate_beta(stock_tickers, market_ticker, start_date, end_date)
+                return jsonify(result)
+                
+            elif metric_type == 'alphacomparison':
+                result = calculate_alpha(stock_tickers, market_ticker, start_date, end_date, risk_free_rate)
+                return jsonify(result)
+                
+            elif metric_type == 'drawdown':
+                result = calculate_drawdown(stock_tickers, start_date, end_date)
+                result_json = {ticker: result[ticker].to_dict() for ticker in result}
+                return jsonify(result_json)
+                
+            elif metric_type == 'cumulative_return':
+                result = calculate_cumulative_return(stock_tickers, start_date, end_date)
+                result_json = {ticker: result[ticker].to_dict() for ticker in result}
+                return jsonify(result_json)
+                
+            elif metric_type == 'sortino_ratio':
+                result = calculate_sortino_ratio(stock_tickers, start_date, end_date, risk_free_rate)
+                return jsonify(result)
+                
+            elif metric_type == 'correlation':
+                result = calculate_correlation_with_market(stock_tickers, market_ticker, start_date, end_date)
+                result_json = {ticker: result[ticker].to_dict() for ticker in result}
+                return jsonify(result_json)
+                
+            elif metric_type == 'sharpe_ratio':
+                result = calculate_sharpe_ratio(stock_tickers, start_date, end_date, risk_free_rate)
+                return jsonify(result)
+                
+            elif metric_type == 'volatility':
+                result = calculate_volatility(stock_tickers, start_date, end_date)
+                return jsonify(result)
+                
+            elif metric_type == 'value_at_risk':
+                result = calculate_value_at_risk(stock_tickers, start_date, end_date, confidence_level)
+                return jsonify(result)
+                
+            elif metric_type == 'efficient_frontier':
+                result = calculate_efficient_frontier(stock_tickers, start_date, end_date, risk_free_rate=risk_free_rate)
+                return jsonify(result)
+
+            else:
+                return jsonify({"error": f"Unknown metric type: {metric_type}"}), 400
+                
+        except Exception as e:
+            return jsonify({"error": str(e)}), 500
+
+    @app.route("/api/betaanalysis", methods=['GET'])
     def get_beta():
         betas = calculate_beta(stock_tickers, market_ticker, start_date, end_date)
         return jsonify(betas)
 
-    @app.route("/api/alpha", methods=['GET'])
+    @app.route("/api/alphacomparison", methods=['GET'])
     def get_alpha():
         benchmark_data = fetch_stock_data([market_ticker], start_date, end_date)
         benchmark_returns = benchmark_data.pct_change().dropna()[market_ticker]
         alphas = calculate_alpha(stock_tickers, benchmark_returns, start_date, end_date, risk_free_rate)
         return jsonify(alphas)
 
-    @app.route("/api/drawdown", methods=['GET'])
+    @app.route("/api/maxdrawdownanalysis", methods=['GET'])
     def get_drawdown():
         drawdowns = calculate_drawdown(stock_tickers, start_date, end_date)
         drawdowns_json = {ticker: drawdowns[ticker].to_dict() for ticker in drawdowns}
         return jsonify(drawdowns_json)
 
-    @app.route("/api/cumulative_return", methods=['GET'])
+    @app.route("/api/cumulativereturncomparison", methods=['GET'])
     def get_cumulative_return():
         cumulative_returns = calculate_cumulative_return(stock_tickers, start_date, end_date)
         cumulative_returns_json = {ticker: cumulative_returns[ticker].to_dict() for ticker in cumulative_returns}
         return jsonify(cumulative_returns_json)
 
-    @app.route("/api/sortino_ratio", methods=['GET'])
+    @app.route("/api/sortinoratiovisualization", methods=['GET'])
     def get_sortino_ratio():
         sortino_ratios = calculate_sortino_ratio(stock_tickers, start_date, end_date, risk_free_rate)
         return jsonify(sortino_ratios)
 
-    @app.route("/api/correlation", methods=['GET'])
+    @app.route("/api/marketcorrelationanalysis", methods=['GET'])
     def get_correlation():
         correlations = calculate_correlation_with_market(stock_tickers, market_ticker, start_date, end_date)
         correlations_json = {ticker: correlations[ticker].to_dict() for ticker in correlations}
         return jsonify(correlations_json)
 
-    @app.route("/api/sharpe_ratio", methods=['GET'])
+    @app.route("/api/sharperatiomatrix", methods=['GET'])
     def get_sharpe_ratio():
         sharpe_ratios = calculate_sharpe_ratio(stock_tickers, start_date, end_date, risk_free_rate)
         return jsonify(sharpe_ratios)
@@ -155,13 +233,13 @@ def create_app():
         volatilities_json = {ticker: volatilities[ticker] for ticker in volatilities}
         return jsonify(volatilities_json)
 
-    @app.route("/api/value_at_risk", methods=['GET'])
+    @app.route("/api/valueatriskanalysis", methods=['GET'])
     def get_value_at_risk():
         value_at_risk = calculate_value_at_risk(stock_tickers, start_date, end_date)
         value_at_risk_json = {ticker: value_at_risk[ticker] for ticker in value_at_risk}
         return jsonify(value_at_risk_json)
 
-    @app.route("/api/efficient_frontier", methods=['GET'])
+    @app.route("/api/efficientfrontiervisualization", methods=['GET'])
     def get_efficient_frontier():
         efficient_frontier = calculate_efficient_frontier(stock_tickers, start_date, end_date)
         return jsonify(efficient_frontier)

--- a/server/src/server.py
+++ b/server/src/server.py
@@ -142,38 +142,38 @@ def create_app():
                 result = calculate_alpha(stock_tickers, market_ticker, start_date, end_date, risk_free_rate)
                 return jsonify(result)
                 
-            elif metric_type == 'drawdown':
+            elif metric_type == 'maxdrawdownanalysis':
                 result = calculate_drawdown(stock_tickers, start_date, end_date)
                 result_json = {ticker: result[ticker].to_dict() for ticker in result}
                 return jsonify(result_json)
                 
-            elif metric_type == 'cumulative_return':
+            elif metric_type == 'cumulativereturncomparison':
                 result = calculate_cumulative_return(stock_tickers, start_date, end_date)
                 result_json = {ticker: result[ticker].to_dict() for ticker in result}
                 return jsonify(result_json)
                 
-            elif metric_type == 'sortino_ratio':
+            elif metric_type == 'sortinoratiovisualization':
                 result = calculate_sortino_ratio(stock_tickers, start_date, end_date, risk_free_rate)
                 return jsonify(result)
                 
-            elif metric_type == 'correlation':
+            elif metric_type == 'marketcorrelationanalysis':
                 result = calculate_correlation_with_market(stock_tickers, market_ticker, start_date, end_date)
                 result_json = {ticker: result[ticker].to_dict() for ticker in result}
                 return jsonify(result_json)
                 
-            elif metric_type == 'sharpe_ratio':
+            elif metric_type == 'sharperatiomatrix':
                 result = calculate_sharpe_ratio(stock_tickers, start_date, end_date, risk_free_rate)
                 return jsonify(result)
                 
-            elif metric_type == 'volatility':
+            elif metric_type == 'volatilityanalysis':
                 result = calculate_volatility(stock_tickers, start_date, end_date)
                 return jsonify(result)
                 
-            elif metric_type == 'value_at_risk':
+            elif metric_type == 'valueatriskanalysis':
                 result = calculate_value_at_risk(stock_tickers, start_date, end_date, confidence_level)
                 return jsonify(result)
                 
-            elif metric_type == 'efficient_frontier':
+            elif metric_type == 'efficientfrontiervisualization':
                 result = calculate_efficient_frontier(stock_tickers, start_date, end_date, risk_free_rate=risk_free_rate)
                 return jsonify(result)
 
@@ -223,7 +223,7 @@ def create_app():
         sharpe_ratios = calculate_sharpe_ratio(stock_tickers, start_date, end_date, risk_free_rate)
         return jsonify(sharpe_ratios)
 
-    @app.route("/api/volatility", methods=['GET'])
+    @app.route("/api/volatilityanalysis", methods=['GET'])
     def get_volatility():
         volatilities = calculate_volatility(stock_tickers, start_date, end_date)
         volatilities_json = {ticker: volatilities[ticker] for ticker in volatilities}


### PR DESCRIPTION
# Pull Request Details

## Summary
On the portfolio page, now all metrics (except 1) can be picked and display a graph according to user specification. Uses backend to actually calculate metrics.


## Related Issue
Closes #101 

## Implementation Changes
Change Type | What | Why
-- | -- | --
**feat** | Portfolio can now display bar, line, and scatter plot graphs | These are required graph types for the used metrics. The metric values are now actually displayed instead of the old fake ohlc
**fix** | Graphs now correctly display stocks in different colours | Previously all stocks were the same colour, making it difficult to understand which corresponded to which
**feat** | fetchMetrics now actually fetches metrics and returns different values depending on metricType | fetchMetrics used to filter by date then return without doing anything else. It now handles the response based on the metricType which need different things. 
**feat** | Volatility metric added as an option | It was all set up but users couldnt pick it. Presumably just accidently skipped
  
## How Has This Been Tested?
All metrics tested to see if they can display a graph with varying inputs such as date range and colour

## Checklist

* [X] Code builds and runs locally without errors
* [X] New and existing tests pass (`npm test`)
* [X] Updated relevant documentation (README, API docs)
* [X] CI/CD checks are green
* [X] Figma prototype link is up to date
* [X] No sensitive data or secrets committed

## Other Notes 
* MaxDrawdown metric occasionally crashes when attempting to load graph. The reason why and fix is being investigated.
* MarketCorrelation can't display a graph because all the data points are NaN. It is a bug in the backend not the frontend. Should display correctly once backend bug is fixed. Backend fix is being investigated

