### PR TITLE
update design of maarket news

### DIFF
--- a/client/components/NewsCardComponent.tsx
+++ b/client/components/NewsCardComponent.tsx
@@ -1,14 +1,17 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Box, Button, Typography, CircularProgress,
-        Dialog, DialogTitle, DialogContent, DialogActions, Select, MenuItem,
-        Card, CardMedia, CardContent, Grid } from '@mui/material';
 import {
-  fetchGeneralNews,
-  fetchRegionalNews,
-  fetchIndustryNews,
-  fetchCommodityNews,
-  fetchTickerNews,
-  Article
+  Box, Typography, CircularProgress, Dialog, DialogTitle, DialogContent,
+  DialogActions, Select, MenuItem, Grid, Card, CardContent, CardMedia,
+  IconButton, Button, Chip
+} from '@mui/material';
+import FullscreenIcon from '@mui/icons-material/Fullscreen';
+import FullscreenExitIcon from '@mui/icons-material/FullscreenExit';
+import TuneIcon from '@mui/icons-material/Tune';
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import {
+  fetchGeneralNews, fetchRegionalNews, fetchIndustryNews,
+  fetchCommodityNews, fetchTickerNews, Article
 } from '@/services/news';
 
 const regionalOptions  = [ 'au','cn','jp','us','gb' ];
@@ -20,13 +23,15 @@ export interface NewsCardComponentProps {
   title: string;
   height?: number | string;
   filterTicker?: string;
+  paramOverride?: string;
+  limit?: number;
+  dark?: boolean;
+  fullscreenOffsetTop?: number;
 }
 
 const NewsCardComponent: React.FC<NewsCardComponentProps> = ({
-  index,
-  height = 300,
-  title,
-  filterTicker,
+  index, height = 300, title, filterTicker, paramOverride, limit,
+  dark = false, fullscreenOffsetTop = 0
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -38,40 +43,44 @@ const NewsCardComponent: React.FC<NewsCardComponentProps> = ({
   const [openSettings, setOpenSettings] = useState(false);
   const [param, setParam]               = useState<string>('');
 
-  // initial param
+  const theme  = useTheme();
+  const isXs   = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const usedLimit     = limit ?? (isXs ? 6 : 12);
+  const imgHeight     = isXs ? 120 : 140;
+  const isControlled  = typeof paramOverride !== 'undefined';
+  const effectiveParam = isControlled ? paramOverride : param;
+
   useEffect(() => {
     const key = ['general','watchlist','regional','industry','commodity'][index];
     const saved = window.localStorage.getItem(`news-param-${key}`);
     setParam(saved || '');
   }, [index]);
 
-  // Pull data
   useEffect(() => {
     let canceled = false;
-    setLoading(true);
-    setError(null);
+    setLoading(true); setError(null);
 
     if (index === 1 && !filterTicker) {
-      setArticles([]);
-      setLoading(false);
-      return;
+      setArticles([]); setLoading(false); return;
     }
+
     let p: Promise<Article[]>;
     switch (index) {
-      case 0: p = fetchGeneralNews(10); break;
-      case 1: p = fetchTickerNews(filterTicker!, 10); break;
-      case 2: p = fetchRegionalNews(param || 'au',  10); break;
-      case 3: p = fetchIndustryNews(param || 'technology', 10); break;
-      case 4: p = fetchCommodityNews(param || 'gold', 10); break;
-      default:
-        p = Promise.resolve([]);
+      case 0: p = fetchGeneralNews(usedLimit); break;
+      case 1: p = fetchTickerNews(filterTicker!, usedLimit); break;
+      case 2: p = fetchRegionalNews(effectiveParam || 'au', usedLimit); break;
+      case 3: p = fetchIndustryNews(effectiveParam || 'technology', usedLimit); break;
+      case 4: p = fetchCommodityNews(effectiveParam || 'gold', usedLimit); break;
+      default: p = Promise.resolve([]);
     }
+
     p.then(a => { if (!canceled) setArticles(a); })
      .catch(e => { if (!canceled) setError((e as Error).message); })
      .finally(() => { if (!canceled) setLoading(false); });
 
     return () => { canceled = true; };
-  }, [index, param, filterTicker]);
+  }, [index, effectiveParam, filterTicker, usedLimit]);
 
   const onSaveSettings = () => {
     const key = ['general','watchlist','regional','industry','commodity'][index];
@@ -79,117 +88,141 @@ const NewsCardComponent: React.FC<NewsCardComponentProps> = ({
     setOpenSettings(false);
   };
 
+  const cardBg   = dark ? '#0d0d0d' : 'background.paper';
+  const line     = dark ? 'rgba(255,255,255,0.12)' : 'divider';
+  const titleCol = dark ? '#fff' : 'text.primary';
+  const textCol  = dark ? 'rgba(255,255,255,0.72)' : 'text.secondary';
 
   return (
     <>
+      {isFullscreen && (
+        <Box
+          sx={{
+            position: 'fixed',
+            top: fullscreenOffsetTop,
+            left: 0,
+            width: '100vw',
+            height: `calc(100vh - ${fullscreenOffsetTop}px)`,
+            bgcolor: '#000',
+            zIndex: (theme) => theme.zIndex.modal, 
+          }}
+        />
+      )}
 
-    <Box
-      ref={containerRef}
-      sx={{
-        position: isFullscreen ? 'fixed' : 'relative',
-        top:      isFullscreen ? 0 : undefined,
-        left:     isFullscreen ? 0 : undefined,
-        width:    isFullscreen ? '100vw' : '100%',
-        height:   isFullscreen ? '100vh' : height,
-        minHeight: 0, 
-        bgcolor:  '#111',
-        border:   '1px solid #555',
-        p:        1,
-        zIndex:   isFullscreen ? 1200 : undefined,
-
-        display:       'flex',
-        flexDirection: 'column',
-      }}
-    >
-      {/* Title + Controls */}
-      <Box sx={{ position: 'relative' }}>
-        <Typography variant="subtitle1" sx={{ color: 'white' }}>
-          {title}
-        </Typography>
-
-        <Box sx={{ position: 'absolute', top: 8, right: 8, display: 'flex', gap: 1 }}>
-            <Button variant="contained" size="small" onClick={() => setIsFullscreen(f => !f)}>
-            {isFullscreen ? '⤡' : '⤢'}
-          </Button>
-            {index >= 2 && (
-              <Button variant="contained" size="small" onClick={()=>setOpenSettings(true)}>⚙︎</Button>
-            )}
-        </Box>
-      </Box>
-
-      {/* Content */}
       <Box
+        ref={containerRef}
         sx={{
-          flex: 1,
-          mt: 1,
-          overflowY: 'auto',
+          position: isFullscreen ? 'fixed' : 'relative',
+          top:      isFullscreen ? fullscreenOffsetTop : undefined,
+          left:     isFullscreen ? 0 : undefined,
+          width:    isFullscreen ? '100vw' : '100%',
+          height:   isFullscreen ? `calc(100vh - ${fullscreenOffsetTop}px)` : height,
           minHeight: 0,
-          pr: 1,
+          bgcolor: 'transparent',
+          p: 0,
+          zIndex:  isFullscreen ? (theme) => theme.zIndex.modal + 1 : 'auto',
+          display: 'flex',
+          flexDirection: 'column',
         }}
       >
-        {loading && (
-          <Box sx={{ textAlign: 'center', mt: 4 }}>
-            <CircularProgress size={24} color="inherit" />
+        <Box sx={{ display:'flex', alignItems:'center', justifyContent:'space-between', pb: 1 }}>
+          <Chip
+            label={title}
+            size="small"
+            sx={{
+              color: dark ? '#fff' : 'inherit',
+              borderColor: line
+            }}
+            variant="outlined"
+          />
+          <Box sx={{ display:'flex', gap: 0.5 }}>
+            <IconButton size="small" onClick={() => setIsFullscreen(f => !f)} aria-label="toggle fullscreen" sx={{ color: dark ? '#fff' : 'inherit' }}>
+              {isFullscreen ? <FullscreenExitIcon fontSize="small" /> : <FullscreenIcon fontSize="small" />}
+            </IconButton>
+            {!isControlled && index >= 2 && (
+              <IconButton size="small" onClick={() => setOpenSettings(true)} aria-label="settings" sx={{ color: dark ? '#fff' : 'inherit' }}>
+                <TuneIcon fontSize="small" />
+              </IconButton>
+            )}
           </Box>
-        )}
+        </Box>
 
-        {error && (
-          <Typography sx={{ color: 'salmon', mt: 2 }}>
-            Failed load: {error}
-          </Typography>
-        )}
+        <Box sx={{ flex: 1, overflowY: 'auto', minHeight: 0 }}>
+          {loading && (
+            <Box sx={{ textAlign: 'center', mt: 4, color: dark ? '#fff' : 'inherit' }}>
+              <CircularProgress size={24} />
+            </Box>
+          )}
 
-        {!loading && !error && (
+          {error && (
+            <Typography sx={{ color: 'salmon', mt: 2 }}>
+              Failed to load: {error}
+            </Typography>
+          )}
+
+          {!loading && !error && (
             <Grid container spacing={2}>
               {articles.map(a => (
                 <Grid item xs={12} sm={6} md={4} key={a.id}>
-                  <Card sx={{
-                    height: '100%',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    borderRadius: 2,
-                    boxShadow: 3,
-                    '&:hover': { boxShadow: 6 },
-                  }}>
+                  <Card
+                    component="a"
+                    href={a.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    sx={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      height: '100%',
+                      textDecoration: 'none',
+                      boxShadow: 'none',
+                      border: '1px solid',
+                      borderColor: line,
+                      bgcolor: cardBg,
+                      borderRadius: 2,
+                      transition: 'transform .15s ease, box-shadow .15s ease',
+                      '&:hover': { transform: 'translateY(-2px)', boxShadow: 3 }
+                    }}
+                  >
                     <CardMedia
                       component="img"
-                      height="120"
+                      height={isXs ? 120 : 140}
                       image={a.image ?? '/placeholder.jpg'}
                       alt={a.title}
+                      loading="lazy"
+                      sx={{ borderTopLeftRadius: 8, borderTopRightRadius: 8 }}
                     />
-                    <CardContent sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+                    <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 1, flex: 1 }}>
                       <Typography
-                        component="a"
-                        href={a.url}
-                        target="_blank"
-                        rel="noreferrer"
                         variant="subtitle1"
                         sx={{
-                          mb: 1,
-                          color: '#4ea1ff',
-                          textDecoration: 'none',
-                          fontWeight: 500,
-                          '&:hover': { textDecoration: 'underline' },
+                          fontWeight: 600, lineHeight: 1.25,
+                          display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical',
+                          overflow: 'hidden', color: titleCol
                         }}
                       >
                         {a.title}
                       </Typography>
-                      <Typography
-                        variant="body2"
-                        color="text.secondary"
-                        sx={{ flex: 1, mb: 1 }}
-                      >
-                        {a.summary}
-                      </Typography>
-                      <Box sx={{
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'center',
-                      }}>
-                        <Typography variant="caption" sx={{ color: '#999' }}>
+
+                      {a.summary && (
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            color: textCol,
+                            display: '-webkit-box',
+                            WebkitLineClamp: 3,
+                            WebkitBoxOrient: 'vertical',
+                            overflow: 'hidden'
+                          }}
+                        >
+                          {a.summary}
+                        </Typography>
+                      )}
+
+                      <Box sx={{ mt: 'auto', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                        <Typography variant="caption" sx={{ color: textCol }}>
                           {new Date(a.publishedAt).toLocaleDateString()}
                         </Typography>
-                        <Typography variant="caption" sx={{ color: '#999' }}>
+                        <Typography variant="caption" sx={{ color: textCol, ml: 1, whiteSpace: 'nowrap' }}>
                           {a.source}
                         </Typography>
                       </Box>
@@ -202,32 +235,21 @@ const NewsCardComponent: React.FC<NewsCardComponentProps> = ({
         </Box>
       </Box>
 
-    {/* Settings Dialog */}
-      <Dialog open={openSettings} onClose={()=>setOpenSettings(false)}>
+      <Dialog open={openSettings} onClose={() => setOpenSettings(false)}>
         <DialogTitle>Set {title}</DialogTitle>
         <DialogContent>
-          <Select
-            fullWidth
-            value={param}
-            onChange={e=>setParam(e.target.value)}
-          >
-            {(index === 2 ? regionalOptions
-             : index === 3 ? industryOptions
-             : commodityOptions
-            ).map(opt=>(
-              <MenuItem key={opt} value={opt}>
-                {opt.toUpperCase()}
-              </MenuItem>
+          <Select fullWidth value={param} onChange={e => setParam(e.target.value)}>
+            {(index === 2 ? regionalOptions : index === 3 ? industryOptions : commodityOptions).map(opt => (
+              <MenuItem key={opt} value={opt}>{opt.toUpperCase()}</MenuItem>
             ))}
           </Select>
         </DialogContent>
         <DialogActions>
-          <Button onClick={()=>setOpenSettings(false)}>Cancel</Button>
+          <Button onClick={() => setOpenSettings(false)}>Cancel</Button>
           <Button onClick={onSaveSettings}>Save</Button>
         </DialogActions>
       </Dialog>
-
-      </>
+    </>
   );
 };
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
+        "@mui/icons-material": "^5.18.0",
         "@mui/material": "^5.16.7",
         "@nextui-org/react": "^2.4.6",
         "@supabase/auth-js": "^2.65.0",
@@ -1799,6 +1800,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.18.0.tgz",
+      "integrity": "sha512-1s0vEZj5XFXDMmz3Arl/R7IncFqJ+WQ95LDp1roHWGDE2oCO3IS4/hmiOv1/8SD9r6B7tv9GLiqVZYHo+6PkTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
+    "@mui/icons-material": "^5.18.0",
     "@mui/material": "^5.16.7",
     "@nextui-org/react": "^2.4.6",
     "@supabase/auth-js": "^2.65.0",

--- a/client/pages/MarketNews.tsx
+++ b/client/pages/MarketNews.tsx
@@ -1,80 +1,209 @@
-import React from "react";
-import Sidebar from "@/components/sidebar";
-import { Box } from "@mui/material";
-import NewsCardComponent from "@/components/NewsCardComponent";
+import React, { useEffect, useMemo, useState } from 'react';
+import { Box, Tabs, Tab, FormControl, InputLabel, Select, MenuItem, Divider, Chip, Stack } from '@mui/material';
+import Sidebar from '@/components/sidebar';
+import NewsCardComponent from '@/components/NewsCardComponent';
+import { useAuth } from '@/components/authContext';
+import supabase from '@/components/supabase';
+
+type TabKey = 'general' | 'watchlist' | 'regional' | 'industry' | 'commodity';
+
+const TOPBAR_H = 64;
 
 const MarketNews: React.FC = () => {
-  const titles = [
-    "General News",
-    "Watchlist News",
-    "Regional News",
-    "Industry News",
-    "Commodity News",
-    "Portfolio News",
-  ];
+  const { user } = useAuth();
+
+  const [active, setActive] = useState<TabKey>('general');
+  const [region, setRegion] = useState('au');
+  const [industry, setIndustry] = useState('technology');
+  const [commodity, setCommodity] = useState('gold');
+  const [limit, setLimit] = useState<number>(12);
+
+  const [watchlistSyms, setWatchlistSyms] = useState<string[]>([]);
+  const [watchSel, setWatchSel] = useState<'ALL' | string>('ALL');
+
+  useEffect(() => {
+    if (!user) { setWatchlistSyms([]); setWatchSel('ALL'); return; }
+    (async () => {
+      const { data, error } = await supabase
+        .from('user_watchlist')
+        .select('symbol, position')
+        .eq('user_id', user.id)
+        .order('position', { ascending: true });
+
+      if (error) { console.error('load watchlist failed:', error); setWatchlistSyms([]); setWatchSel('ALL'); return; }
+
+      const symbols = (data ?? []).map(d => d.symbol).filter(Boolean) as string[];
+      setWatchlistSyms(symbols);
+      setWatchSel(prev => (prev !== 'ALL' && symbols.includes(prev) ? prev : 'ALL'));
+    })();
+  }, [user]);
+
+  const watchlistQuery = useMemo(() => {
+    if (!watchlistSyms.length) return '';
+    return watchSel === 'ALL'
+      ? watchlistSyms.slice(0, 3).join(' OR ')
+      : watchSel;
+  }, [watchlistSyms, watchSel]);
+
+  const chipSx = (active: boolean) => ({
+    color: active ? '#fff' : 'rgba(255,255,255,0.88)',
+    borderColor: 'rgba(255,255,255,0.36)',
+    bgcolor: active ? 'secondary.main' : 'rgba(255,255,255,0.08)',
+    fontWeight: 600,
+    '&:hover': {
+        bgcolor: active ? 'secondary.dark' : 'rgba(255,255,255,0.16)',
+        borderColor: 'rgba(255,255,255,0.48)',
+    },
+    });
+
+  const section = useMemo(() => {
+    const commonProps = { height: '100%', limit, dark: true, fullscreenOffsetTop: TOPBAR_H } as const;
+
+    switch (active) {
+      case 'general':
+        return <NewsCardComponent {...commonProps} index={0} title="General News" />;
+      case 'watchlist':
+        return (
+          <NewsCardComponent
+            {...commonProps}
+            index={1}
+            title={watchSel === 'ALL' ? 'Watchlist News' : `Watchlist · ${watchSel}`}
+            filterTicker={watchlistQuery || undefined}
+          />
+        );
+      case 'regional':
+        return <NewsCardComponent {...commonProps} index={2} title="Regional News" paramOverride={region} />;
+      case 'industry':
+        return <NewsCardComponent {...commonProps} index={3} title="Industry News" paramOverride={industry} />;
+      case 'commodity':
+        return <NewsCardComponent {...commonProps} index={4} title="Commodity News" paramOverride={commodity} />;
+      default:
+        return null;
+    }
+  }, [active, region, industry, commodity, limit, watchlistQuery, watchSel]);
 
   return (
-    <Box sx={{ display: "flex", height: "100vh", minHeight: 0 }}>
+    <Box sx={{ display: 'flex', height: '100vh', bgcolor: '#000', color: '#fff' }}>
       <Sidebar />
 
-      <Box
-        component="main"
-        sx={{
-          flex: 1,
-          pl: "50px",
-          bgcolor: "black",
-          display: "flex",
-          flexDirection: "column",
-          gap: 1,
-          minHeight: 0,
-        }}
-      >
-        {/* Up-row */}
-        <Box sx={{ display: "flex", flex: 3, gap: 1, minHeight: 0 }}>
-          {/* General News */}
-          <Box sx={{ flex: 2, display: "flex", minHeight: 0 }}>
-            <NewsCardComponent index={0} title={titles[0]} height="100%" />
-          </Box>
-
-          {/* Watchlist */}
-          <Box
+      <Box component="main" sx={{ flex: 1, pl: { xs: 0, md: '50px' }, pr: 2, py: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+        <Box
+          sx={(theme) => ({
+            position: 'sticky',
+            top: 0,
+            zIndex: theme.zIndex.appBar,
+            bgcolor: '#000',
+            borderBottom: '1px solid rgba(255,255,255,0.12)'
+          })}
+        >
+          <Tabs
+            value={active}
+            onChange={(_, v) => setActive(v)}
+            textColor="inherit"
+            indicatorColor="secondary"
+            variant="scrollable"
+            scrollButtons="auto"
             sx={{
-              flex: 1,
-              display: "flex",
-              flexDirection: "column",
-              gap: 1,
-              minHeight: 0,
+                minHeight: TOPBAR_H,
+                '& .MuiTab-root': {
+                opacity: 1,                           
+                color: 'rgba(255,255,255,0.80)',       
+                fontWeight: 600,
+                },
+                '& .MuiTab-root.Mui-selected': {
+                color: '#fff',                          
+                },
             }}
-          >
-            {[1].map((idx) => (
-              <Box
-                key={idx}
-                sx={{ flex: 1, display: "flex", minHeight: 0 }}
+            >
+
+            <Tab label="GENERAL" value="general" />
+            <Tab label="WATCHLIST" value="watchlist" />
+            <Tab label="REGIONAL" value="regional" />
+            <Tab label="INDUSTRY" value="industry" />
+            <Tab label="COMMODITY" value="commodity" />
+          </Tabs>
+
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 2, py: 1, borderTop: '1px solid rgba(255,255,255,0.08)' }}>
+            {active === 'regional' && (
+              <FormControl size="small" sx={{ minWidth: 140 }}>
+                <InputLabel id="region-label" sx={{ color: '#fff' }}>Region</InputLabel>
+                <Select
+                  labelId="region-label" label="Region" value={region} onChange={e => setRegion(e.target.value)}
+                  sx={{ color: '#fff', '.MuiOutlinedInput-notchedOutline': { borderColor: 'rgba(255,255,255,0.24)' } }}
+                >
+                  {['au','cn','jp','us','gb'].map(r => <MenuItem key={r} value={r}>{r.toUpperCase()}</MenuItem>)}
+                </Select>
+              </FormControl>
+            )}
+
+            {active === 'industry' && (
+              <FormControl size="small" sx={{ minWidth: 180 }}>
+                <InputLabel id="industry-label" sx={{ color: '#fff' }}>Industry</InputLabel>
+                <Select
+                  labelId="industry-label" label="Industry" value={industry} onChange={e => setIndustry(e.target.value)}
+                  sx={{ color: '#fff', '.MuiOutlinedInput-notchedOutline': { borderColor: 'rgba(255,255,255,0.24)' } }}
+                >
+                  {['technology','health','finance','internet','pharmaceutical'].map(i => <MenuItem key={i} value={i}>{i}</MenuItem>)}
+                </Select>
+              </FormControl>
+            )}
+
+            {active === 'commodity' && (
+              <FormControl size="small" sx={{ minWidth: 160 }}>
+                <InputLabel id="commodity-label" sx={{ color: '#fff' }}>Commodity</InputLabel>
+                <Select
+                  labelId="commodity-label" label="Commodity" value={commodity} onChange={e => setCommodity(e.target.value)}
+                  sx={{ color: '#fff', '.MuiOutlinedInput-notchedOutline': { borderColor: 'rgba(255,255,255,0.24)' } }}
+                >
+                  {['gold','oil','wheat','copper','silver'].map(c => <MenuItem key={c} value={c}>{c}</MenuItem>)}
+                </Select>
+              </FormControl>
+            )}
+
+            {active === 'watchlist' && (
+                <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', alignItems: 'center' }}>
+                    <Chip
+                    label="ALL"
+                    size="small"
+                    clickable
+                    onClick={() => setWatchSel('ALL')}
+                    variant="filled"
+                    sx={chipSx(watchSel === 'ALL')}
+                    />
+                    {watchlistSyms.length ? (
+                    watchlistSyms.map(sym => (
+                        <Chip
+                        key={sym}
+                        label={sym}
+                        size="small"
+                        clickable
+                        onClick={() => setWatchSel(sym)}
+                        variant="filled"
+                        sx={chipSx(watchSel === sym)}
+                        />
+                    ))
+                    ) : (
+                    <Chip label={user ? 'No symbols yet' : 'Sign in to load watchlist'} size="small" variant="outlined" sx={chipSx(false)} />
+                    )}
+                </Stack>
+                )}
+
+            <FormControl size="small" sx={{ minWidth: 110, marginLeft: 'auto' }}>
+              <InputLabel id="limit-label" sx={{ color: '#fff' }}>Items</InputLabel>
+              <Select
+                labelId="limit-label" label="Items" value={limit} onChange={e => setLimit(Number(e.target.value))}
+                sx={{ color: '#fff', '.MuiOutlinedInput-notchedOutline': { borderColor: 'rgba(255,255,255,0.24)' } }}
               >
-                <NewsCardComponent
-                  index={idx}
-                  title={titles[idx]}
-                  height="100%"
-                />
-              </Box>
-            ))}
+                {[6, 9, 12, 15].map(n => <MenuItem key={n} value={n}>{n}</MenuItem>)}
+              </Select>
+            </FormControl>
           </Box>
         </Box>
 
-        {/* Down-row */}
-        <Box sx={{ display: "flex", flex: 2, gap: 1, minHeight: 0 }}>
-          {[2, 3, 4].map((idx) => (
-            <Box
-              key={idx}
-              sx={{ flex: 1, display: "flex", minHeight: 0 }}
-            >
-              <NewsCardComponent
-                index={idx}
-                title={titles[idx]}
-                height="100%"
-              />
-            </Box>
-          ))}
+        <Divider sx={{ opacity: 0.1 }} />
+
+        <Box sx={{ flex: 1, minHeight: 0, pt: 1 }}>
+          {section}
         </Box>
       </Box>
     </Box>


### PR DESCRIPTION
# Pull Request Details

## Summary

Revamp the **Market News** experience with a black theme, a clear top navigation, fullscreen improvements, and tight **Watchlist** integration with Supabase.

* New top nav: `GENERAL | WATCHLIST | REGIONAL | INDUSTRY | COMMODITY` (default: **GENERAL**)
* Contextual sub-options below the nav (region/industry/commodity pickers; Watchlist chips)
* Fullscreen overlay prevents overlap with bottom content
* Watchlist news powered by the user’s saved symbols; chips at the top let you switch between **ALL** or a single symbol

## Related Issue

Closes #110 

## Implementation Changes

* **feat:** Top navigation & contextual sub-bar

  * Sticky black nav (high-contrast tabs) with default `GENERAL`
  * Sub-bar shows: Region/Industry/Commodity selects, or Watchlist symbol chips
* **feat:** Watchlist integration

  * Read `user_watchlist (symbol, position)` from Supabase
  * Build query string (`SYM1 OR SYM2 OR SYM3`) for “ALL” view; clicking a chip filters to that single symbol
  * Display current watchlist as clickable chips beneath the nav
* **feat:** Fullscreen behavior

  * Add black overlay and `fullscreenOffsetTop` so fullscreen content starts below the nav and never overlaps the bottom
* **refactor:** Card and page styles

  * Black theme, lightweight cards (`#0d0d0d` with subtle dividers), unified info hierarchy (Title 2 lines → Summary 3 lines → Date | Source)
  * Brighter tab/chip contrast on dark background
* **fix:** Watchlist robustness

  * Trim/uppercase symbols; drop empty values to avoid blank chips
* **chore:** Component API

  * `NewsCardComponent` now accepts `paramOverride`, `limit`, `dark`, `fullscreenOffsetTop` to allow page-level control

**Why:**
Reduce visual weight, make “what I’m viewing” obvious, connect Watchlist to news without extra input, and ensure fullscreen reading is clean on black UI.

## UI / UX

Before：                                                    
<img width="1680" height="924" alt="截屏2025-09-25 上午11 24 33" src="https://github.com/user-attachments/assets/e5a9785d-2295-4fbc-b976-9dacf74abe4e" />
 After:
<img width="1680" height="925" alt="截屏2025-09-25 上午11 23 28" src="https://github.com/user-attachments/assets/540221bd-ffe9-49ce-9016-cf665a18b7a6" />
 

## How Has This Been Tested?

* Local manual tests (Chrome/Safari, narrow and ultra-wide)
* Default tab is **GENERAL** on load
* Tab and sub-option changes re-fetch and render immediately
* Supabase read for `user_watchlist` under authenticated session; chips render as **ALL + symbols**
* Clicking **ALL** uses combined `SYM1 OR SYM2 OR SYM3`; clicking a single chip uses that symbol only
* Fullscreen places a black overlay under the card and below the sticky nav; no bottom bleed-through; exit restores layout
* Empty/unauthenticated states render friendly chips/messages

## Checklist

* [ ] Code builds and runs locally without errors
* [ ] New and existing tests pass (`npm test`)
* [ ] Updated relevant documentation (README, API docs)
* [ ] CI/CD checks are green
* [ ] Figma prototype link is up to date (if applicable)
* [ ] No sensitive data or secrets committed

## Other Notes

* Next steps:
  * Enrich Watchlist query with company names (e.g., `AAPL OR "Apple Inc."`) to boost recall
  * Replace `CardMedia` with `next/image` + `sizes` for better LCP
