### PR TITLE
Watchlist chart prop compatibility follow-up

### DIFF
--- a/client/components/WatchlistCollapsibleCard.tsx
+++ b/client/components/WatchlistCollapsibleCard.tsx
@@ -81,9 +81,6 @@ const WatchlistCollapsibleCard: React.FC<Props> = ({
           onActivate={handleActivate}
           onUpdateSettings={handleUpdateSettings}
           height={height}
-          defaultStart={defaultStart}
-          defaultEnd={defaultEnd}
-          color={color}
           showSwap={false}
         />
       </Box>

--- a/client/components/WatchlistCollapsibleCard.tsx
+++ b/client/components/WatchlistCollapsibleCard.tsx
@@ -81,6 +81,15 @@ const WatchlistCollapsibleCard: React.FC<Props> = ({
           onActivate={handleActivate}
           onUpdateSettings={handleUpdateSettings}
           height={height}
+          /*
+           * These values are already folded into cardSettings above.
+           * Keep the old prop names here as context from the DevBranch merge,
+           * but do not pass them until StockChartCardProps supports them.
+           *
+           * defaultStart={defaultStart}
+           * defaultEnd={defaultEnd}
+           * color={color}
+           */
           showSwap={false}
         />
       </Box>


### PR DESCRIPTION
## Summary
- Keep the legacy `defaultStart`, `defaultEnd`, and `color` prop names as merge context in `WatchlistCollapsibleCard`.
- Avoid passing unsupported props into `StockChartCard` until its prop contract supports them.

## Related Issues
- Refs #175

## Verification
- Not rerun for this PR in the current turn; this branch contains a small comment-only compatibility follow-up.