### PR TITLE
Refine shared sidebar responsiveness and navigation tokens

### DIFF
--- a/client/components/learning/LearningPageLayout.module.css
+++ b/client/components/learning/LearningPageLayout.module.css
@@ -6,8 +6,8 @@
   --learning-accent-border: #1d2a5c;
   --learning-support-bg: #0a0818;
   --learning-support-border: #1c2a5c;
-  --learning-active-bg: #101939;
-  --learning-active-border: #203773;
+  --learning-active-bg: var(--fit-nav-active-bg, #101939);
+  --learning-active-border: var(--fit-nav-active-border, #203773);
   --learning-idle-bg: var(--fit-color-field, #18181b);
 }
 

--- a/client/components/shared/fitStyles.ts
+++ b/client/components/shared/fitStyles.ts
@@ -3,12 +3,17 @@ export const fitNav = {
     "group flex min-h-[44px] min-w-0 touch-manipulation items-center gap-3 rounded-lg px-3 py-2 text-left transition-[background-color,color,box-shadow] duration-150",
   itemActive:
     "bg-gradient-to-r from-[#1f2466] via-[#24175a] to-[#3a155f] text-white shadow-[inset_0_0_0_1px_rgba(123,140,255,0.42),0_12px_28px_rgba(83,103,255,0.18)]",
+  itemActiveQuiet:
+    "bg-[var(--fit-nav-active-bg)] text-white shadow-[inset_0_0_0_1px_var(--fit-nav-active-border)]",
   itemActiveCompact:
     "bg-[#101225] text-white shadow-[inset_0_0_0_1px_rgba(123,140,255,0.28),0_0_24px_rgba(83,103,255,0.12)]",
+  itemActiveCompactQuiet:
+    "bg-[var(--fit-nav-active-bg)] text-[var(--fit-color-accent-strong)] shadow-[inset_0_0_0_1px_var(--fit-nav-active-border)]",
   itemIdle:
     "text-[#a5adbf] hover:bg-[linear-gradient(135deg,rgba(83,103,255,0.10),rgba(124,58,237,0.12))] hover:text-[#f4f7ff]",
   iconActive:
     "bg-white/[0.12] text-white shadow-[inset_0_0_0_1px_rgba(255,255,255,0.12)]",
+  iconActiveQuiet: "bg-[#141419] text-[var(--fit-color-accent-strong)]",
   iconActiveStandalone:
     "bg-gradient-to-br from-[#5367ff] via-[#6d4cff] to-[#2b164f] text-white shadow-[0_0_22px_rgba(83,103,255,0.42),inset_0_0_0_1px_rgba(213,220,255,0.24)]",
   iconIdle: "bg-[#141419] text-[#8f98aa] group-hover:text-[#dce4ff]",
@@ -19,10 +24,8 @@ export const fitNav = {
 } as const;
 
 export const fitButton = {
-  primary:
-    "bg-[#5d67ff] text-white transition-colors hover:bg-[#7079ff]",
-  secondary:
-    "bg-[#15151a] text-[#dce4ff] transition-colors hover:bg-[#20212a]",
+  primary: "bg-[#5d67ff] text-white transition-colors hover:bg-[#7079ff]",
+  secondary: "bg-[#15151a] text-[#dce4ff] transition-colors hover:bg-[#20212a]",
   subtle:
     "text-[#8f98aa] transition-colors hover:bg-white/[0.04] hover:text-[#f3f6ff]",
 } as const;

--- a/client/components/sidebar.tsx
+++ b/client/components/sidebar.tsx
@@ -88,7 +88,9 @@ function shouldKeepDesktopSidebarExpanded() {
 function getInitialExpandedMode() {
   if (getInitialCompactMode()) return rememberedCompactExpanded
 
-  return shouldKeepDesktopSidebarExpanded()
+  if (getInitialHoverExpandMode()) return shouldKeepDesktopSidebarExpanded()
+
+  return rememberedDesktopExpanded
 }
 
 interface SidebarNavItem {
@@ -263,8 +265,9 @@ const Sidebar: React.FC<SidebarProps> = ({
   const [showLogin, setShowLogin] = useState(false)
   const [compact, setCompact] = useState(getInitialCompactMode)
   const [canHoverExpand, setCanHoverExpand] = useState(getInitialHoverExpandMode)
+  const [responsiveReady, setResponsiveReady] = useState(false)
   const sidebarRef = useRef<HTMLElement | null>(null)
-  const compactToggleRef = useRef<HTMLButtonElement | null>(null)
+  const manualToggleRef = useRef<HTMLButtonElement | null>(null)
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const previousCompactDrawerOpenRef = useRef(false)
   const pointerInsideRef = useRef(false)
@@ -274,6 +277,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   const collapsedWidth = compact ? COMPACT_COLLAPSED_WIDTH : DESKTOP_COLLAPSED_WIDTH
   const visualWidth = expanded ? EXPANDED_WIDTH : collapsedWidth
   const layoutWidth = compact ? collapsedWidth : visualWidth
+  const showManualToggle = compact || (responsiveReady && !canHoverExpand)
   const pathname = router.pathname
 
   useEffect(() => {
@@ -286,7 +290,7 @@ const Sidebar: React.FC<SidebarProps> = ({
     if (expanded) {
       if (
         (compact && rememberedCompactExpanded) ||
-        (rememberedDesktopExpanded && !compact && canHoverExpand)
+        (rememberedDesktopExpanded && !compact)
       ) {
         setShowLabel(true)
       } else {
@@ -318,6 +322,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 
       setCompact(nextCompact)
       setCanHoverExpand(nextCanHoverExpand)
+      setResponsiveReady(true)
 
       if (nextCompact) {
         setExpanded(rememberedCompactExpanded)
@@ -327,9 +332,9 @@ const Sidebar: React.FC<SidebarProps> = ({
       }
 
       if (!nextCanHoverExpand) {
-        setExpanded(false)
-        setShowLabel(false)
-        onHoverChange?.(false)
+        setExpanded(rememberedDesktopExpanded)
+        setShowLabel(rememberedDesktopExpanded)
+        onHoverChange?.(rememberedDesktopExpanded)
         return
       }
 
@@ -391,9 +396,9 @@ const Sidebar: React.FC<SidebarProps> = ({
     const compactDrawerOpen = compact && expanded
 
     if (compactDrawerOpen) {
-      compactToggleRef.current?.focus()
+      manualToggleRef.current?.focus()
     } else if (previousCompactDrawerOpenRef.current) {
-      compactToggleRef.current?.focus()
+      manualToggleRef.current?.focus()
     }
 
     previousCompactDrawerOpenRef.current = compactDrawerOpen
@@ -411,7 +416,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 
     if (compact) {
       rememberedCompactExpanded = nextExpanded
-    } else if (canHoverExpand) {
+    } else {
       rememberedDesktopExpanded = nextExpanded
     }
 
@@ -425,7 +430,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 
       if (compact) {
         rememberedCompactExpanded = false
-      } else if (canHoverExpand) {
+      } else {
         rememberedDesktopExpanded = false
       }
 
@@ -443,12 +448,13 @@ const Sidebar: React.FC<SidebarProps> = ({
 
     if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
       if (!compact && pointerInsideRef.current) return
+      if (!compact && !canHoverExpand) return
 
       setExpandedState(false)
     }
   }
 
-  function handleCompactToggle() {
+  function handleManualToggle() {
     setExpandedState(!expanded)
   }
 
@@ -545,7 +551,7 @@ const Sidebar: React.FC<SidebarProps> = ({
         onKeyDownCapture={trapCompactDrawerFocus}
         onPointerDownCapture={markPointerInteraction}
         onFocusCapture={() => {
-          if (!compact && !pointerInteractionRef.current) {
+          if (!compact && canHoverExpand && !pointerInteractionRef.current) {
             setExpandedState(true)
           }
         }}
@@ -567,9 +573,9 @@ const Sidebar: React.FC<SidebarProps> = ({
         style={{ width: visualWidth, colorScheme: 'dark' }}
       >
         <div className="border-b border-[#141622] px-2 py-4">
-          {compact ? (
+          {showManualToggle ? (
             <button
-              ref={compactToggleRef}
+              ref={manualToggleRef}
               type="button"
               aria-controls="app-sidebar-navigation"
               aria-expanded={expanded}
@@ -579,7 +585,7 @@ const Sidebar: React.FC<SidebarProps> = ({
                 expanded ? 'justify-start px-2' : 'justify-center px-0',
                 focusRing,
               ].join(' ')}
-              onClick={handleCompactToggle}
+              onClick={handleManualToggle}
             >
               <span
                 className="grid h-8 w-8 shrink-0 place-items-center rounded-md bg-gradient-to-br from-[#14182d] via-[#151126] to-[#0f1016] text-[#8ea0ff] shadow-[inset_0_0_0_1px_rgba(123,140,255,0.16)]"

--- a/client/features/community/components/CommunitySidebar.tsx
+++ b/client/features/community/components/CommunitySidebar.tsx
@@ -193,7 +193,7 @@ export function CommunitySidebar({
           <div
             className={cn(
               "rounded-lg py-2 text-center",
-              fitNav.itemActiveCompact,
+              fitNav.itemActiveCompactQuiet,
             )}
             aria-label={activeItem ? `Current view: ${activeItem.label}` : undefined}
           >
@@ -204,7 +204,7 @@ export function CommunitySidebar({
             <div
               className={cn(
                 "rounded-lg py-2 text-center",
-                fitNav.itemActiveCompact,
+                fitNav.itemActiveCompactQuiet,
               )}
               aria-label={
                 activeTimeItem
@@ -255,14 +255,14 @@ export function CommunitySidebar({
                   fitNav.itemBase,
                   "relative min-w-[142px] lg:min-w-0",
                   drawerOpen ? "min-w-0" : "",
-                  active ? fitNav.itemActive : fitNav.itemIdle,
+                  active ? fitNav.itemActiveQuiet : fitNav.itemIdle,
                   FOCUS_VISIBLE,
                 )}
               >
                 <span
                   className={cn(
                     "grid h-8 w-8 shrink-0 place-items-center rounded-md transition-colors",
-                    active ? fitNav.iconActive : fitNav.iconIdle,
+                    active ? fitNav.iconActiveQuiet : fitNav.iconIdle,
                   )}
                   aria-hidden="true"
                 >
@@ -311,14 +311,14 @@ export function CommunitySidebar({
                   className={cn(
                     "group flex min-h-[38px] min-w-[132px] touch-manipulation items-center gap-2 rounded-lg px-3 py-2 text-left text-sm font-bold transition-colors lg:min-w-0",
                     drawerOpen ? "min-w-0" : "",
-                    active ? fitNav.itemActive : fitNav.itemIdle,
+                    active ? fitNav.itemActiveQuiet : fitNav.itemIdle,
                     FOCUS_VISIBLE,
                   )}
                 >
                   <span
                     className={cn(
                       "grid h-7 w-7 shrink-0 place-items-center rounded-md transition-colors",
-                      active ? fitNav.iconActive : fitNav.iconIdle,
+                      active ? fitNav.iconActiveQuiet : fitNav.iconIdle,
                     )}
                     aria-hidden="true"
                   >

--- a/client/pages/Profile.tsx
+++ b/client/pages/Profile.tsx
@@ -61,7 +61,8 @@ const sanitizePhone = (value: string) =>
 
 const isValidEmail = (value: string) => /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(value)
 
-const hasLetter = (value: string) => /\p{L}/u.test(value)
+const hasLetter = (value: string) =>
+  Array.from(value).some((char) => char.toLocaleLowerCase() !== char.toLocaleUpperCase())
 
 const validateName = (label: string, value: string) => {
   if (!value) return `${label} is required`
@@ -373,7 +374,11 @@ function Profile() {
     <div className="min-h-screen bg-black text-white">
       <Sidebar />
 
-      <main className="min-h-screen px-5 py-6 md:ml-[50px] md:px-8 lg:px-10">
+      <main
+        id="main-content"
+        tabIndex={-1}
+        className="ml-[var(--app-sidebar-width,52px)] min-h-screen min-w-0 overflow-x-hidden px-5 py-6 outline-none transition-[margin-left] duration-200 ease-out md:px-8 lg:px-10"
+      >
         <div className="mx-auto w-full max-w-[1280px]">
           <header className="flex flex-col gap-4 border-b border-white/15 pb-6 md:flex-row md:items-center md:justify-between">
             <div>

--- a/client/styles/globals.css
+++ b/client/styles/globals.css
@@ -18,6 +18,8 @@
     --fit-color-text-label: #687184;
     --fit-color-accent: #8ea0ff;
     --fit-color-accent-strong: #65a0fd;
+    --fit-nav-active-bg: #101939;
+    --fit-nav-active-border: #203773;
   }
 
   @media (max-width: 767px) {


### PR DESCRIPTION
## Summary
- show the shared sidebar expand/collapse control consistently on touch devices across screen sizes while preserving desktop hover behavior
- make the Profile page follow the shared sidebar width CSS variable so it resizes with sidebar expand/collapse
- centralize quiet navigation active colors in shared FIT tokens and apply them to Community, Guide, and Help navigation states
- replace the Profile Unicode property regex with a build-safe letter detection helper

## Related issues
Refs #193
Refs #194
Refs #168
Refs #138

## Verification
- `npx prettier --check components/sidebar.tsx pages/Profile.tsx components/shared/fitStyles.ts components/learning/LearningPageLayout.module.css features/community/components/CommunitySidebar.tsx styles/globals.css`
- `npm run lint`
- `npm run build`
- verified `/Profile` returns 200 on a fresh local dev server